### PR TITLE
Check hdr for history field

### DIFF
--- a/spm12/metadata/init_output_metadata_structure.m
+++ b/spm12/metadata/init_output_metadata_structure.m
@@ -32,7 +32,7 @@ for cinput = 1:size(input_files,1)
     filename = spm_file(input_files(cinput,:),'number','');
     metastruc.history.input{cinput}.filename = filename;
     hdr = get_metadata(filename);
-    if ~isempty(hdr{1})
+    if ~isempty(hdr{1}) && isfield(hdr{1},'history')
         metastruc.history.input{cinput}.history = hdr{1}.history;
     else
         metastruc.history.input{cinput}.history = 'No history available.';


### PR DESCRIPTION
Similar to a poster on the email list, I got an error regarding no `history` field in `hdr` in `init_output_metadata_structure.m`, line 36.

I first checked if the field existed in the data but wasn't being kept somehow. I converted my images using `dcm2niix`, but neither the converted NIfTIs nor the original DICOMs had a `history` field. My guess, then, is that `history` is not a universal DICOM field and so should not be assumed to exist in the data.

This PR adds a conditional to check if `hdr` has a `history` field. If it does, it adds it to `metastruc.history`, as intended before. If it doesn't, it just writes `'No history available.'` to `metastruc.history`, the same as it was already doing if `hdr` was totally empty.