### PR TITLE
Fix jhdr size

### DIFF
--- a/spm12/metadata/get_jhdr_and_offset.m
+++ b/spm12/metadata/get_jhdr_and_offset.m
@@ -1,9 +1,10 @@
-function [jhdr, offset] = get_jhdr_and_offset(hdr)
+function [jhdr, jhdr_size, offset] = get_jhdr_and_offset(hdr)
 %==========================================================================
 % FORMAT
-% [jhdr, offset] = get_jhdr_and_offset(hdr)
+% [jhdr, jhdr_size, offset] = get_jhdr_and_offset(hdr)
 % hdr       a Matlab structure
 % jhdr      the JSONified Matlab structure
+% jhdr_size size of the JSON header encoding in bytes
 % offset    the offset at which image data start in the nifti file
 %==========================================================================
 % Written by
@@ -13,9 +14,14 @@ function [jhdr, offset] = get_jhdr_and_offset(hdr)
 % JSONify the Matlab structure
 jhdr = spm_jsonwrite(hdr,struct('indent','\t'));
 
+% simulate header write, fprintf() returns actual bytes written. length()
+% doesn't work here because characters might be larger than one byte (UTF-8)
+fid = fopen(tempname, 'w');
+jhdr_size = fprintf(fid, '%s', jhdr);
+fclose(fid);
 % the length of the extension includes two 32-bit numbers = 8 bytes (the
 % size of the extension itself and the ID of the extension):
-ext_hdr_size = length(jhdr)+8;
+ext_hdr_size = jhdr_size+8;
 
 % the offset must be >352+ext_hdr_size AND a multiple of 16
 offset = ceil((352+ext_hdr_size)/16)*16;

--- a/spm12/metadata/get_jhdr_and_offset.m
+++ b/spm12/metadata/get_jhdr_and_offset.m
@@ -16,9 +16,12 @@ jhdr = spm_jsonwrite(hdr,struct('indent','\t'));
 
 % simulate header write, fprintf() returns actual bytes written. length()
 % doesn't work here because characters might be larger than one byte (UTF-8)
-fid = fopen(tempname, 'w');
+sim_fname = tempname();
+fid = fopen(sim_fname, 'w');
 jhdr_size = fprintf(fid, '%s', jhdr);
 fclose(fid);
+delete(sim_fname);
+
 % the length of the extension includes two 32-bit numbers = 8 bytes (the
 % size of the extension itself and the ID of the extension):
 ext_hdr_size = jhdr_size+8;

--- a/spm12/metadata/init_metadata.m
+++ b/spm12/metadata/init_metadata.m
@@ -50,7 +50,7 @@ metadata.acqpar = hdr;
 
 if json.extended
     % JSONify the header and calculate the required offset
-    [jhdr, offset] = get_jhdr_and_offset(metadata);
+    [jhdr, jhdr_size, offset] = get_jhdr_and_offset(metadata);
     % modify the offset of the nifti
     N.dat.offset = offset;
     % make the offset modification effective by rewriting the standard
@@ -58,7 +58,7 @@ if json.extended
     create(N);
     % write the extended header (can be done before data are written or
     % after, does not matter:
-    write_extended_header(N.dat.fname,jhdr);
+    write_extended_header(N.dat.fname,jhdr,jhdr_size);
 end
 
 if json.separate

--- a/spm12/metadata/set_metadata.m
+++ b/spm12/metadata/set_metadata.m
@@ -123,7 +123,7 @@ for cfile = 1:size(filelist,1)
         % create handle to NIFTI object
         N = nifti(fullfile(pth, [fnam '.nii']));
         % create JSONified header and calculate NIFTI extended offset
-        [jhdr, offset] = get_jhdr_and_offset(mstruc);
+        [jhdr, jhdr_size, offset] = get_jhdr_and_offset(mstruc);
         % modify the nifti file offset 
         N.dat.offset = offset;
         % make this change effective by rewriting the NIFTI header
@@ -140,6 +140,6 @@ for cfile = 1:size(filelist,1)
             end
         end
         % write the extended header
-        write_extended_header(fullfile(pth, [fnam '.nii']),jhdr);
+        write_extended_header(fullfile(pth, [fnam '.nii']),jhdr,jhdr_size);
     end
 end

--- a/spm12/metadata/write_extended_header.m
+++ b/spm12/metadata/write_extended_header.m
@@ -1,9 +1,10 @@
-function write_extended_header(fnam, jhdr)
+function write_extended_header(fnam, jhdr, jhdr_size)
 %==========================================================================
 % FORMAT
-% write_extended_header(fnam, jsonhdr)
+% write_extended_header(fnam, jhdr, jhdr_size)
 % fnam      the name of a nifti file
-% jsonhdr   the JSONified Matlab structure to be written as extended header
+% jhdr      the JSONified Matlab structure to be written as extended header
+% jhdr_size size of the JSON header encoding in bytes
 %==========================================================================
 % Written by
 % - Evelyne Balteau, Cyclotron Research Centre, Liège, Belgium
@@ -16,7 +17,7 @@ std_hdr_size = 348;
 isHdrExtended = [1 0 0 0];
 % the length of the extension includes two 32-bit numbers = 8 bytes (the
 % size itself and the ID of the extension):
-ext_hdr_size = length(jhdr)+8;
+ext_hdr_size = jhdr_size+8;
 % ID of the extension (32-bit number) = anything > 4, arbitrarily set to 27
 % for now, just because I like this number :)...
 ext_hdr_id = 27;


### PR DESCRIPTION
My approach to fix #8 

Basically carry the json header size around and remove assumption that length(jhdr) is the byte count of jhdr.