### PR TITLE
Bug fix #9

### DIFF
--- a/hmri_create_MTProt.m
+++ b/hmri_create_MTProt.m
@@ -934,7 +934,7 @@ if PDproc.T2scorr && (~isempty(fR2s)||~isempty(fR2s_OLS))
 end
 
 % PD map calculation continued
-if ~isempty(f_T) && (mpm_params.UNICORT.PD || ~mpm_params.UNICORT.R1)
+if ~isempty(f_T) && ~isempty(fA) && exist('fTPM','var') && (mpm_params.UNICORT.PD || ~mpm_params.UNICORT.R1)
     % if calibration enabled, do the Unified Segmentation bias correction
     % if required and calibrate the PD map
     if PDproc.calibr


### PR DESCRIPTION
Bug related to the entangled implementation of MTProt :(...
For the time being, here is the analysis of the situation and a quick fix.

First of all, given that no T1w images are available, the only maps that can be generated are R2s and an MTR map, and the rest of the code should have been skipped. The call to [`PDcalculation`](https://github.com/hMRI-group/hMRI-toolbox/blob/8dea911bbe731083e0cd1f7801f09b8bd4a7a601/hmri_create_MTProt.m#L941) should not have happened at all.

This is actually checked while generating the summary log at the [end of the `get_mpm_params` function](https://github.com/hMRI-group/hMRI-toolbox/blob/8dea911bbe731083e0cd1f7801f09b8bd4a7a601/hmri_create_MTProt.m#L1450-L1610). But the connection between this check point and the effective calculation seems indeed to have some loose ends :(... And the call to [`PDcalculation`](https://github.com/hMRI-group/hMRI-toolbox/blob/8dea911bbe731083e0cd1f7801f09b8bd4a7a601/hmri_create_MTProt.m#L941) is one of them...

Simple fix has been implemented, that checks whether all required ingredients to go ahead with PDcalibration are available...