### PR TITLE
Adding ability to push registration flags to spm_coreg

### DIFF
--- a/config/hmri_defaults.m
+++ b/config/hmri_defaults.m
@@ -135,6 +135,28 @@ hmri_def.segment.warp.write = [0 0];
 hmri_def.coreg2PDw = 1; 
 
 %--------------------------------------------------------------------------
+% Coregistration parameters for weighted images to the average 
+% (or TE=0 fit) PDw image; see spm_coreg.m for details
+%--------------------------------------------------------------------------
+% For high resolution (< 0.8 mm) data, we have found that adding extra 
+% steps to the registration can improve map quality, e.g. for 0.5 mm data
+% we have found
+%   hmri_def.coreg_flags.sep=[4 2 1 0.5];
+% to be needed to avoid registration artefacts, but this comes at the 
+% expense of slowing down map creation
+hmri_def.coreg_flags.sep=[4 2];
+hmri_def.coreg_flags.cost_fun = 'nmi';
+hmri_def.coreg_flags.fwhm = [7 7];
+
+%--------------------------------------------------------------------------
+% Coregistration parameters for B1 bias maps to the average (or TE=0 fit) 
+% PDw image; see spm_coreg.m for details
+%--------------------------------------------------------------------------
+hmri_def.coreg_bias_flags.sep=[4 2];
+hmri_def.coreg_bias_flags.cost_fun = 'nmi';
+hmri_def.coreg_bias_flags.fwhm = [7 7];
+
+%--------------------------------------------------------------------------
 % Ordinary Least Squares & fit at TE=0
 %--------------------------------------------------------------------------
 % create an Ordinary Least Squares R2* map. The ESTATICS model is applied

--- a/config/local/hmri_local_defaults.m
+++ b/config/local/hmri_local_defaults.m
@@ -137,6 +137,28 @@ hmri_def.segment.warp.write = [0 0];
 hmri_def.coreg2PDw = 1; 
 
 %--------------------------------------------------------------------------
+% Coregistration parameters for weighted images to the average 
+% (or TE=0 fit) PDw image; see spm_coreg.m for details
+%--------------------------------------------------------------------------
+% For high resolution (< 0.8 mm) data, we have found that adding extra 
+% steps to the registration can improve map quality, e.g. for 0.5 mm data
+% we have found
+%   hmri_def.coreg_flags.sep=[4 2 1 0.5];
+% to be needed to avoid registration artefacts, but this comes at the 
+% expense of slowing down map creation
+hmri_def.coreg_flags.sep=[4 2];
+hmri_def.coreg_flags.cost_fun = 'nmi';
+hmri_def.coreg_flags.fwhm = [7 7];
+
+%--------------------------------------------------------------------------
+% Coregistration parameters for B1 bias maps to the average (or TE=0 fit) 
+% PDw image; see spm_coreg.m for details
+%--------------------------------------------------------------------------
+hmri_def.coreg_bias_flags.sep=[4 2];
+hmri_def.coreg_bias_flags.cost_fun = 'nmi';
+hmri_def.coreg_bias_flags.fwhm = [7 7];
+
+%--------------------------------------------------------------------------
 % Ordinary Least Squares & fit at TE=0
 %--------------------------------------------------------------------------
 % create an Ordinary Least Squares R2* map. The ESTATICS model is applied

--- a/hmri_create_MTProt.m
+++ b/hmri_create_MTProt.m
@@ -270,16 +270,16 @@ hmri_log(sprintf('\t-------- Coregistering the images --------'),mpm_params.nopu
 % NOTE: coregistration can be disabled using the hmri_def.coreg2PDw flag
 
 x_MT2PD = [0 0 0 0 0 0];
-if MTwidx; 
+if MTwidx 
     if mpm_params.coreg
-        x_MT2PD = coreg_mt(Pavg{PDwidx}, Pavg{MTwidx});
+        x_MT2PD = coreg_mt(Pavg{PDwidx}, Pavg{MTwidx}, mpm_params.coreg_flags);
     end
 end
 x_T12PD = [0 0 0 0 0 0];   
-if T1widx; 
+if T1widx 
     if mpm_params.coreg
-        x_T12PD = coreg_mt(Pavg{PDwidx}, Pavg{T1widx});
-        coreg_mt(Pavg{PDwidx}, PT1w_forA);
+        x_T12PD = coreg_mt(Pavg{PDwidx}, Pavg{T1widx}, mpm_params.coreg_flags);
+        coreg_mt(Pavg{PDwidx}, PT1w_forA, mpm_params.coreg_flags);
     end
 end
 
@@ -289,7 +289,7 @@ if ~isempty(P_trans)
     % P_trans(1,:) = magnitude image (anatomical reference for coregistration) 
     % P_trans(2,:) = B1 map (p.u.)
     if mpm_params.coreg
-        coreg_bias_map(Pavg{PDwidx}, P_trans);
+        coreg_bias_map(Pavg{PDwidx}, P_trans, mpm_params.coreg_bias_flags);
     end
     V_trans = spm_vol(P_trans);
 end
@@ -1025,13 +1025,12 @@ end
 %% =======================================================================%
 % To coregister the structural images for MT protocol 
 %=========================================================================%
-function [x] = coreg_mt(P_ref, P_src)
+function [x] = coreg_mt(P_ref, P_src, coreg_flags)
 
 for src_nr = 1:size(P_src,1)
     VG = spm_vol(P_ref);
     VF = spm_vol(P_src(src_nr,:));
-    coregflags.sep = [4 2];
-    x = spm_coreg(VG,VF, coregflags);
+    x = spm_coreg(VG,VF,coreg_flags);
     M  = inv(spm_matrix(x));
     MM = spm_get_space(deblank(VF.fname));
     spm_get_space(deblank(deblank(VF.fname)), M*MM); %#ok<*MINV>
@@ -1042,15 +1041,12 @@ end
 % To coregister the B1 or receive maps with the anatomical images in the
 % MT protocol. 
 %=========================================================================%
-function [] = coreg_bias_map(P_ref, P_src)
+function [] = coreg_bias_map(P_ref, P_src, coreg_bias_flags)
 
 P_src(1,:);
 VG = spm_vol(P_ref);
 VF = spm_vol(P_src(1,:));
-%coregflags.sep = [2 1];
-coregflags.sep = [4 2];
-x = spm_coreg(VG,VF, coregflags);
-%x  = spm_coreg(mireg(i).VG, mireg(i).VF,flags.estimate);
+x = spm_coreg(VG,VF,coreg_bias_flags);
 M  = inv(spm_matrix(x));
 MM = spm_get_space(deblank(VF.fname));
 spm_get_space(deblank(deblank(VF.fname)), M*MM);
@@ -1441,6 +1437,16 @@ end
 
 % coregistration of all images to the PDw average (or TE=0 fit):
 mpm_params.coreg = hmri_get_defaults('coreg2PDw');
+
+% coregistration flags for weighted images
+mpm_params.coreg_flags = hmri_get_defaults('coreg_flags');
+hmri_log(sprintf('=== Registration Settings for weighted images ==='),mpm_params.nopuflags);
+hmri_log(sprintf('Method: %s, Sampling: %s, Smoothing: %s', mpm_params.coreg_flags.cost_fun, mat2str(mpm_params.coreg_flags.sep), mat2str(mpm_params.coreg_flags.fwhm)),mpm_params.nopuflags);
+
+% coregistration flags for B1 to PDw
+mpm_params.coreg_bias_flags = hmri_get_defaults('coreg_bias_flags');
+hmri_log(sprintf('=== Registration Settings for B1 bias images ==='),mpm_params.nopuflags);
+hmri_log(sprintf('Method: %s, Sampling: %s, Smoothing: %s', mpm_params.coreg_bias_flags.cost_fun, mat2str(mpm_params.coreg_bias_flags.sep), mat2str(mpm_params.coreg_bias_flags.fwhm)),mpm_params.nopuflags);
 
 % Prepare output for R1, PD, MT and R2* maps
 RFsenscorr = fieldnames(mpm_params.proc.RFsenscorr);


### PR DESCRIPTION
 Adding ability to push registration flags to spm_coreg using the hmri defaults files. This is helpful for high resolution data, where the default registration parameters can be too coarse, giving rise to registration artefacts in the maps.