### PR TITLE
Put UNICORT option back

### DIFF
--- a/tbx_scfg_hmri_B1_menu.m
+++ b/tbx_scfg_hmri_B1_menu.m
@@ -1,4 +1,4 @@
-function b1_type = tbx_scfg_hmri_B1_menu
+function [b1_type,b1parameters] = tbx_scfg_hmri_B1_menu
 % Configuration file for the "histological MRI" (hMRI) toolbox
 % Previously named "Voxel-Based Quantification" (VBQ)
 % -> Dealing with menu options for the creation of B1 maps

--- a/tbx_scfg_hmri_create.m
+++ b/tbx_scfg_hmri_create.m
@@ -81,6 +81,12 @@ raws.val        = {raws1 raws2 raws3};
 [b1_type,b1parameters] = tbx_scfg_hmri_B1_menu;
 
 % ---------------------------------------------------------------------
+% New B1 mapping methods should be added to tbx_scfg_hmri_B1_menu.m
+% Only B1 mapping methods which cannot be run independently of the rest of 
+% the hMRI toolbox should be added here!
+% ---------------------------------------------------------------------
+
+% ---------------------------------------------------------------------
 % UNICORT B1 bias correction
 % ---------------------------------------------------------------------
 b1_input_UNICORT           = cfg_branch;
@@ -91,7 +97,6 @@ b1_input_UNICORT.help      = {'UNICORT will be applied for B1 bias correction.'
     ['Customized processing parameters may be introduced by loading ' ...
     'customized defaults from a selected [hmri_b1_local_defaults_*.m] file.']};
 b1_input_UNICORT.val       = {b1parameters};
-
 % ---------------------------------------------------------------------
 % No B1 bias correction
 % ---------------------------------------------------------------------
@@ -104,9 +109,11 @@ b1_input_noB1.help      = {'No B1 bias correction will be applied.'
 b1_input_noB1.strtype = 's';
 b1_input_noB1.num     = [1 Inf];
 b1_input_noB1.val     = {'noB1'};
-
+% ---------------------------------------------------------------------
+% Add extra B1 mapping methods which cannot be run independently of the
+% MPM map creation to the menu
+% ---------------------------------------------------------------------
 b1_type.values  = [b1_type.values {b1_input_UNICORT, b1_input_noB1}];
-
 b1_type.help={b1_type.help{1},[' - UNICORT: Use this option when B1 maps not available. ' ...
     'Bias field estimation and correction will be performed ' ...
     'using the approach described in [Weiskopf et al., NeuroImage 2011; 54:2116-2124]. ' ...

--- a/tbx_scfg_hmri_create.m
+++ b/tbx_scfg_hmri_create.m
@@ -78,7 +78,39 @@ raws.val        = {raws1 raws2 raws3};
 % ---------------------------------------------------------------------
 % menu b1_type
 % ---------------------------------------------------------------------
-b1_type = tbx_scfg_hmri_B1_menu;
+[b1_type,b1parameters] = tbx_scfg_hmri_B1_menu;
+
+% ---------------------------------------------------------------------
+% UNICORT B1 bias correction
+% ---------------------------------------------------------------------
+b1_input_UNICORT           = cfg_branch;
+b1_input_UNICORT.tag       = 'UNICORT';
+b1_input_UNICORT.name      = 'UNICORT';
+b1_input_UNICORT.help      = {'UNICORT will be applied for B1 bias correction.'
+    'No B1 input data required.'
+    ['Customized processing parameters may be introduced by loading ' ...
+    'customized defaults from a selected [hmri_b1_local_defaults_*.m] file.']};
+b1_input_UNICORT.val       = {b1parameters};
+
+% ---------------------------------------------------------------------
+% No B1 bias correction
+% ---------------------------------------------------------------------
+b1_input_noB1           = cfg_entry;
+b1_input_noB1.tag       = 'no_B1_correction';
+b1_input_noB1.name      = 'no B1 correction';
+b1_input_noB1.help      = {'No B1 bias correction will be applied.'
+    ['NOTE: when no B1 map is available, UNICORT might be a better ' ...
+    'solution than no B1 bias correction at all.']};
+b1_input_noB1.strtype = 's';
+b1_input_noB1.num     = [1 Inf];
+b1_input_noB1.val     = {'noB1'};
+
+b1_type.values  = [b1_type.values {b1_input_UNICORT, b1_input_noB1}];
+
+b1_type.help={b1_type.help{1},[' - UNICORT: Use this option when B1 maps not available. ' ...
+    'Bias field estimation and correction will be performed ' ...
+    'using the approach described in [Weiskopf et al., NeuroImage 2011; 54:2116-2124]. ' ...
+    'WARNING: the correction only applies to R1 maps.']};
 
 % ---------------------------------------------------------------------
 % Input images for RF sensitivity - RF sensitivity maps for MTw images


### PR DESCRIPTION
Refactoring the B1 mapping so that it could be run independently of the hMRI toolbox accidentally removed the UNICORT and no-B1-correction options from the batch menu. This pull request corrects this oversight.