### PR TITLE
Added reordering of B1 maps following their fa

### DIFF
--- a/hmri_create_b1map.m
+++ b/hmri_create_b1map.m
@@ -220,31 +220,36 @@ json = hmri_get_defaults('json');
 P    = b1map_params.b1input; % B1 data - 11 pairs
 Q    = b1map_params.b0input; % B0 data - 3 volumes
 
-assert(numel(P) == 2 * numel(b1map_params.b1acq.beta), ...
+V = spm_vol(P);
+n = numel(V);
+
+assert(rem(n,2)==0, ...
+   ['B1 mapping image volumes must be a set of SE, STE pairs ' ...
+   'thus the number of input volumes (currently %d) must be even.'], n);
+
+assert(n == 2 * numel(b1map_params.b1acq.beta), ...
    ['Number of B1 mapping image pairs (%d) does not match ' ...
     'the number of nominal flip angles (%d)!'], ...
-    numel(P)/2, numel(b1map_params.b1acq.beta));
+    n/2, numel(b1map_params.b1acq.beta));
 
-% splitting images into P_SE and P_STE volumes
+% splitting images into SE and STE volumes
 % TODO: check that correct data selected (compare echo times?)
-P_SE = P(1:2:end);
-P_STE = P(2:2:end);
+V_SE = V(1:2:end);
+V_STE = V(2:2:end);
 
 % calc_SESTE_b1map expects fa in decreasing order
 [b1map_params.b1acq.beta, fa_order] = sort(b1map_params.b1acq.beta, 'descend');
 
-% rearranging P_SE and P_STE in decreasing fa
-P_SE = P_SE(fa_order);
-P_STE = P_STE(fa_order);
+% rearranging volumes in decreasing fa
+V_SE = V_SE(fa_order);
+V_STE = V_STE(fa_order);
 
 % TODO: Keeping SE and STE separated might be easier to read
 % but requires a lot of code changes below, so merging into
 % original list with corrected order
-P(1:2:end) = P_SE;
-P(2:2:end) = P_STE;
+V(1:2:end) = V_SE;
+V(2:2:end) = V_STE;
 
-V = spm_vol(P);
-n = numel(V);
 Y_tmptmp = zeros([V(1).dim(1:2) n]);
 Y_ab = zeros(V(1).dim(1:3));
 Y_cd = zeros(V(1).dim(1:3));

--- a/hmri_create_b1map.m
+++ b/hmri_create_b1map.m
@@ -227,25 +227,25 @@ end
 
 % splitting images in echo1 and echo2 volumes
 % TODO: check that echo times are as expected
-P_echo1 = P(1:2:end, :);
-P_echo2 = P(2:2:end, :);
+P_SE = P(1:2:end, :);
+P_STE = P(2:2:end, :);
 
 % calc_SESTE_b1map expects fa in decreasing order
 [b1map_params.b1acq.beta, fa_order] = sort(b1map_params.b1acq.beta, ...
                                            'descend');
 % rearanging P_e1 and P_e2 in decreasing fa
-P_echo1 = P_echo1(fa_order, :);
-P_echo2 = P_echo2(fa_order, :);
+P_SE = P_SE(fa_order, :);
+P_STE = P_STE(fa_order, :);
 
-% TODO: In my eyes keeping echo1 and echo2 separated is easier to read:
-% V = [spm_vol(P_echo1) spm_vol(P_echo2)]
+% TODO: In my eyes keeping SE and STE separated is easier to read:
+% V = [spm_vol(P_SE) spm_vol(P_STE)]
 % but requires a lot of code changes below, so merging into same 
 % list with correct order
 
 % Don't use 'end' as hMRI may add B1map and B1ref to P
 % from previous runs
-P(1:2:size(P_echo1, 1)*2, :) = P_echo1;
-P(2:2:size(P_echo2, 1)*2, :) = P_echo2;
+P(1:2:size(P_SE, 1)*2, :) = P_SE;
+P(2:2:size(P_STE, 1)*2, :) = P_STE;
 
 V = spm_vol(P);
 n = numel(V);

--- a/hmri_create_b1map.m
+++ b/hmri_create_b1map.m
@@ -226,6 +226,7 @@ if size(P, 1) ~= 2 * size(b1map_params.b1acq.beta, 2)
 end  
 
 % splitting images in echo1 and echo2 volumes
+% TODO: check that echo times are as expected
 P_echo1 = P(1:2:end, :);
 P_echo2 = P(2:2:end, :);
 
@@ -236,7 +237,7 @@ P_echo2 = P(2:2:end, :);
 P_echo1 = P_echo1(fa_order, :);
 P_echo2 = P_echo2(fa_order, :);
 
-% In my eyes keeping echo1 and echo2 separated is easier to read:
+% TODO: In my eyes keeping echo1 and echo2 separated is easier to read:
 % V = [spm_vol(P_echo1) spm_vol(P_echo2)]
 % but requires a lot of code changes below, so merging into same 
 % list with correct order

--- a/hmri_create_b1map.m
+++ b/hmri_create_b1map.m
@@ -220,6 +220,28 @@ json = hmri_get_defaults('json');
 P    = b1map_params.b1input; % B1 data - 11 pairs
 Q    = b1map_params.b0input; % B0 data - 3 volumes
 
+% splitting images in echo1 and echo2 volumes
+% wold be nice to check that echo times are as expected
+P_e1 = P(1:2:end, :);
+P_e2 = P(2:2:end, :);
+
+% calc_SESTE_b1map expects fa in decreasing order
+[b1map_params.b1acq.beta, fa_order] = sort(b1map_params.b1acq.beta, ...
+                                           'descend');
+% rearanging P_e1 and P_e2 in decreasing fa
+P_e1 = P_e1(fa_order, :);
+P_e2 = P_e2(fa_order, :);
+
+% In my eyes keeping echo1 and echo2 separated is easier to read:
+% V = [spm_vol(P_e1) spm_vol(P_e2)]
+% but requires a lot of code changes below, so merging into same 
+% list with correct order
+
+% Don't use 'end' as hMRI may add B1map and B1ref to P
+% from previous runs
+P(1:2:size(P_e1, 1)*2, :) = P_e1;
+P(2:2:size(P_e2, 1)*2, :) = P_e2;
+
 V = spm_vol(P);
 n = numel(V);
 Y_tmptmp = zeros([V(1).dim(1:2) n]);

--- a/hmri_create_b1map.m
+++ b/hmri_create_b1map.m
@@ -220,27 +220,31 @@ json = hmri_get_defaults('json');
 P    = b1map_params.b1input; % B1 data - 11 pairs
 Q    = b1map_params.b0input; % B0 data - 3 volumes
 
+if size(P, 1) ~= 2 * size(b1map_params.b1acq.beta, 2)
+ error('Expected %d B1 map images, recieved %d', ...
+       2 * size(b1map_params.b1acq.beta, 2), size(P, 1));
+end  
+
 % splitting images in echo1 and echo2 volumes
-% wold be nice to check that echo times are as expected
-P_e1 = P(1:2:end, :);
-P_e2 = P(2:2:end, :);
+P_echo1 = P(1:2:end, :);
+P_echo2 = P(2:2:end, :);
 
 % calc_SESTE_b1map expects fa in decreasing order
 [b1map_params.b1acq.beta, fa_order] = sort(b1map_params.b1acq.beta, ...
                                            'descend');
 % rearanging P_e1 and P_e2 in decreasing fa
-P_e1 = P_e1(fa_order, :);
-P_e2 = P_e2(fa_order, :);
+P_echo1 = P_echo1(fa_order, :);
+P_echo2 = P_echo2(fa_order, :);
 
 % In my eyes keeping echo1 and echo2 separated is easier to read:
-% V = [spm_vol(P_e1) spm_vol(P_e2)]
+% V = [spm_vol(P_echo1) spm_vol(P_echo2)]
 % but requires a lot of code changes below, so merging into same 
 % list with correct order
 
 % Don't use 'end' as hMRI may add B1map and B1ref to P
 % from previous runs
-P(1:2:size(P_e1, 1)*2, :) = P_e1;
-P(2:2:size(P_e2, 1)*2, :) = P_e2;
+P(1:2:size(P_echo1, 1)*2, :) = P_echo1;
+P(2:2:size(P_echo2, 1)*2, :) = P_echo2;
 
 V = spm_vol(P);
 n = numel(V);


### PR DESCRIPTION
This branch addresses issue for B1 maps ordering.

It is essential for bids compatibility ans should be merged into beliy-get-metadata-bids, before that branch is merged into master.

The issue comes from BIDS requirements of ordering flip angles in increasing order instead of decreasing, expected by hMRI.
As for function `CreateMap` the list of flip angles is retrieved only from first file, just reordering the list of passed files do not work.

The fix just reorders files in beginning of `CreateMap` function together with the list of fa values.

There must be similar issues with other parameters retrieved not from individual files, and similar fixes should be applied to them.