### PR TITLE
Fix for Issue #35

### DIFF
--- a/spm12/metadata/get_metadata_val_classic.m
+++ b/spm12/metadata/get_metadata_val_classic.m
@@ -350,11 +350,15 @@ switch inParName
         [nFieldFound, fieldList] = find_field_name(mstruc, 'PhaseEncodingDirectionPositive','caseSens','sensitive','matchType','exact');
         [val,nam] = get_val_nam_list(mstruc, nFieldFound, fieldList);
         % PhaseEncodingDirectionPositive = 0/1 for -1/+1.
-        % Note that null parameters are not saved in the header.
+        % Note that null parameters were not saved in the header in older datasets.
         if nFieldFound
             cRes = 1;
             parLocation{cRes} = nam{1};
-            parValue{cRes} = val{1};
+            if val{1}
+                parValue{cRes} = 1;
+            else 
+                parValue{cRes} = -1;
+            end
         else
             nFieldFound = 1;
             cRes = 1;


### PR DESCRIPTION
As per issue #35, at some point support for negative phase encoding in 3D-EPI B1 maps broke. The bug seems to go back to an assumption made in https://github.com/hMRI-group/hMRI-toolbox/blob/2c55bb3d6569bf643bfb66b68502cfb4d8446687/spm12/metadata/get_metadata_val_classic.m#L348-L363 that "null" values are not written to the Siemens header/SPM json file. At some point this changed (either on the Siemens side or the SPM DICOM import side), and so a PhaseEncodingDirectionSign value of "0" could erroneously propagate through the code. This pull request fixes this issue.