### PR TITLE
Map creation: retain qform in maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog documents all notable changes to the hMRI-toolbox.
 
 Most recent version numbers *should* follow the [Semantic Versioning](https://semver.org/spec/v2.0.0.html) principles (e.g. bug fixes: x.x.1 > x.x.2, new feature with backward compatibility: x.2.x > x.3.0, major release affecting the way data are handled and processed: 1.x.x > 2.0.0).
 
+## [unreleased]
+### Fixed
+- issue #59: both the [qform and the sform](https://nifti.nimh.nih.gov/nifti-1/documentation/nifti1fields/nifti1fields_pages/qsform.html) of the first PD-weighted image are now propagated to the quantitative maps, rather than just the sform
+
 ## [v0.5.0]
 
 ### Added

--- a/hmri_create_nifti.m
+++ b/hmri_create_nifti.m
@@ -1,22 +1,31 @@
-
 function Ni = hmri_create_nifti(Pout, VG, dt, txtdescrip)
-% This function creates a nifti file.
+%hmri_create_nifti Create a nifti file and populate the header
 % S. Mohammadi 06/09/2019
 %
 % In:
 % Pout          - file path and name
-% VG            - target structure of
+% VG            - target structure with orientation information
 % dt            - file type
 % txtdescrip    - description of file
 %
 % Out:
 % Ni            - nifti file
 
-Ni          = nifti;
-Ni.mat      = VG.mat;
-Ni.mat0     = VG.mat;
-Ni.descrip  = txtdescrip;
-Ni.dat      = file_array(Pout,VG.dim,dt,0,1,0);
+% Initialise nifti object
+Ni = nifti;
+
+% Get orientation information from nifti object in VG
+NG             = VG.private;
+Ni.mat         = NG.mat;
+Ni.mat_intent  = NG.mat_intent;
+Ni.mat0        = NG.mat0;
+Ni.mat0_intent = NG.mat0_intent;
+
+% Fill other fields from inputs
+Ni.descrip     = txtdescrip;
+Ni.dat         = file_array(Pout,VG.dim,dt,0,1,0);
+
+% Save nifti object to disk
 create(Ni);
 
 end


### PR DESCRIPTION
Fix for issue #59 which makes sure that the qform and sform along with their respective codes from the first PD-weighted image are preserved in the output multiparameter maps.

Tested on the public dataset: after this fix the toolbox correctly propagates "scanner anatomical" as the qform and sform codes, rather than arbitrarily setting them to "aligned anatomical", as was done previously.