### PR TITLE
Separate MTsat, add different MTsat correction models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This changelog documents all notable changes to the hMRI-toolbox.
 Most recent version numbers *should* follow the [Semantic Versioning](https://semver.org/spec/v2.0.0.html) principles (e.g. bug fixes: x.x.1 > x.x.2, new feature with backward compatibility: x.2.x > x.3.0, major release affecting the way data are handled and processed: 1.x.x > 2.0.0).
 
 ## [unreleased]
+### Added
+- option to choose different models and parameters for B1-correction of MTsat
+
 ### Fixed
 - QUIQI check: dependence on stats toolbox
 - issue #14 (Spatial processing: Inverse deformation field moved along with forward deformation field to requested folder)

--- a/config/hmri_defaults.m
+++ b/config/hmri_defaults.m
@@ -162,6 +162,13 @@ hmri_def.coreg_bias_flags.fwhm = [7 7];
 hmri_def.small_angle_approx = true;
 
 %--------------------------------------------------------------------------
+% Which model to use for B1-correction of MTsat
+%--------------------------------------------------------------------------
+hmri_def.MTsatB1CorrectionModel = 'helms'; % 'helms' or 'lipp'
+hmri_def.MTsatB1CorrectionHelmsC = 0.4; % value for 220° from Helms, et al. (arXiv 2021)
+hmri_def.MTsatB1CorrectionLippC  = 1.2; % value for 700° from Lipp, et al. (MRM 2023)
+
+%--------------------------------------------------------------------------
 % Ordinary Least Squares & fit at TE=0
 %--------------------------------------------------------------------------
 % Create a Least Squares R2* map. The ESTATICS model is applied

--- a/config/local/hmri_local_defaults.m
+++ b/config/local/hmri_local_defaults.m
@@ -164,6 +164,13 @@ hmri_def.coreg_bias_flags.fwhm = [7 7];
 hmri_def.small_angle_approx = true;
 
 %--------------------------------------------------------------------------
+% Which model to use for B1-correction of MTsat
+%--------------------------------------------------------------------------
+hmri_def.MTsatB1CorrectionModel = 'helms'; % 'helms' or 'lipp'
+hmri_def.MTsatB1CorrectionHelmsC = 0.4; % value for 220° from Helms, et al. (arXiv 2021)
+hmri_def.MTsatB1CorrectionLippC  = 1.2; % value for 700° from Lipp, et al. (MRM 2023)
+
+%--------------------------------------------------------------------------
 % Ordinary Least Squares & fit at TE=0
 %--------------------------------------------------------------------------
 % Create a Least Squares R2* map. The ESTATICS model is applied

--- a/examples/hmri_MTsat_Lipp_model_500deg_defaults.m
+++ b/examples/hmri_MTsat_Lipp_model_500deg_defaults.m
@@ -1,0 +1,17 @@
+function hmri_MTsat_Lipp_model_500deg_defaults
+% PURPOSE
+%   These are the suggested defaults for correcting MTsat for B1-inhomogeneity when using the standard Siemens MT-module
+% 
+% CHANGES 
+%   Set correction model to the linear "Lipp" model and scaled the coefficient from a referance MT flip angle of 700° to 500° 
+
+% Global hmri_def variable used across the whole toolbox
+global hmri_def
+
+%--------------------------------------------------------------------------
+% Which model to use for B1-correction of MTsat
+%--------------------------------------------------------------------------
+hmri_def.MTsatB1CorrectionModel = 'lipp'; % 'helms' or 'lipp'
+hmri_def.MTsatB1CorrectionLippC = 1.3; % value for 500° scaled from the 700° value in Lipp, et al. (MRM 2023) using Eq. (S.3) in that paper
+
+end

--- a/hmri_calc_MTsat.m
+++ b/hmri_calc_MTsat.m
@@ -1,0 +1,30 @@
+function MTsat=hmri_calc_MTsat(MTw,A,R1)
+%hmri_calc_MTsat Calculate MTsat from MTw data.
+% 
+% Input:
+%     MTw.data (array of MT-weighted signals)
+%     MTw.fa   (nominal flip angle, rad)
+%     MTw.TR   (repetition time, s or ms)
+%     MTw.B1   (array of B1 ratios: either 1 [classic MTsat] or actual fa / nominal fa [calibrated MTsat for high FA])
+%     A        (unnormalised PD map, must not have been scaled relative to MTw.data)
+%     R1       (R1 estimates, in reciprocal units of MTw.TR)
+%
+% Output:
+%   MTsat (in percent units [p.u.])
+%
+% Examples:
+% References:
+
+if isempty(MTw.B1), MTw.B1=1; end
+
+assert(all(size(MTw.data)==size(A.data)),'hmri:inputArraySize','MTw.data and A must be the same size!')
+assert(all(size(MTw.data)==size(R1.data)),'hmri:inputArraySize','MTw.data and R1 must be the same size!')
+assert(MTw.TR>0,'hmri:TR','MTw.TR must be positive!')
+
+MTsat = ( (A .* (MTw.B1*MTw.fa) - MTw.data) ./ (MTw.data+eps) .* R1*MTw.TR - (MTw.B1*MTw.fa).^2 / 2 ) * 100;
+
+% Make data points with missing data NaN
+nanmask=(MTw.data==0)|(MTw.data==0);
+MTsat(nanmask)=NaN;
+
+end

--- a/hmri_calc_MTsat.m
+++ b/hmri_calc_MTsat.m
@@ -28,8 +28,8 @@ function MTsat = hmri_calc_MTsat(MTw, A, R1)
 
 if isempty(MTw.B1), MTw.B1=1; end
 
-assert(all(size(MTw.data)==size(A.data)),'hmri:inputArraySize','MTw.data and A must be the same size!')
-assert(all(size(MTw.data)==size(R1.data)),'hmri:inputArraySize','MTw.data and R1 must be the same size!')
+assert(all(size(MTw.data)==size(A)), 'hmri:inputArraySize','MTw.data and A must be the same size!')
+assert(all(size(MTw.data)==size(R1)),'hmri:inputArraySize','MTw.data and R1 must be the same size!')
 assert(MTw.TR>0,'hmri:TR','MTw.TR must be positive!')
 
 MTsat = ( (A .* (MTw.B1*MTw.fa) - MTw.data) ./ (MTw.data+eps) .* R1*MTw.TR - (MTw.B1*MTw.fa).^2 / 2 ) * 100;

--- a/hmri_calc_MTsat.m
+++ b/hmri_calc_MTsat.m
@@ -2,18 +2,29 @@ function MTsat=hmri_calc_MTsat(MTw,A,R1)
 %hmri_calc_MTsat Calculate MTsat from MTw data.
 % 
 % Input:
-%     MTw.data (array of MT-weighted signals)
-%     MTw.fa   (nominal flip angle, rad)
-%     MTw.TR   (repetition time, s or ms)
-%     MTw.B1   (array of B1 ratios: either 1 [classic MTsat] or actual fa / nominal fa [calibrated MTsat for high FA])
-%     A        (unnormalised PD map, must not have been scaled relative to MTw.data)
-%     R1       (R1 estimates, in reciprocal units of MTw.TR)
+%   MTw.data (array of MT-weighted signals)
+%   MTw.fa   (nominal excitation flip angle, rad)
+%   MTw.TR   (repetition time, s or ms)
+%   MTw.B1   (array of B1 ratios: either 1 [classic MTsat] or actual fa / nominal fa [calibrated MTsat for high FA])
+%   A        (unnormalised PD map, must not have been scaled relative to MTw.data)
+%   R1       (R1 estimates, in reciprocal units of MTw.TR)
 %
 % Output:
 %   MTsat (in percent units [p.u.])
 %
 % Examples:
+%   % Procedure from Helms (2008) correcting for B1 to second order within the small flip angle regime by setting B1 = 1
+%   A_for_MTsat = hmri_calc_A(struct('data',data_pdw,'fa',fa_pdw,'TR',tr_pdw,'B1',1),...
+%                             struct('data',data_t1w,'fa',fa_t1w,'TR',tr_t1w,'B1',1), true);
+%   R1_for_MTsat = hmri_calc_R1(struct('data',data_pdw,'fa',fa_pdw,'TR',tr_pdw,'B1',1),...
+%                               struct('data',data_t1w,'fa',fa_t1w,'TR',tr_t1w,'B1',1), true);
+%   MTsat = hmri_calc_MTsat(struct('data',data_mtw,'fa',fa_mtw,'TR',tr_mtw,'B1',1), A_for_MTsat, R1_for_MTsat);
+%
 % References:
+%   Helms, et al. (2008), "High-resolution maps of magnetization transfer with inherent correction for RF inhomogeneity 
+%       and T1 relaxation obtained from 3D FLASH MRI". Magn. Reson. Med. https://doi.org/10.1002/mrm.21732
+%   Tabelow, et al. (2019), "hMRI – A toolbox for quantitative MRI in neuroscience and clinical research". Neuroimage 
+%       https://doi.org/10.1016/j.neuroimage.2019.01.029
 
 if isempty(MTw.B1), MTw.B1=1; end
 

--- a/hmri_calc_MTsat.m
+++ b/hmri_calc_MTsat.m
@@ -1,4 +1,4 @@
-function MTsat=hmri_calc_MTsat(MTw,A,R1)
+function MTsat = hmri_calc_MTsat(MTw, A, R1)
 %hmri_calc_MTsat Calculate MTsat from MTw data.
 % 
 % Input:
@@ -13,12 +13,12 @@ function MTsat=hmri_calc_MTsat(MTw,A,R1)
 %   MTsat (in percent units [p.u.])
 %
 % Examples:
-%   % Procedure from Helms (2008) correcting for B1 to second order within the small flip angle regime by setting B1 = 1
-%   A_for_MTsat = hmri_calc_A(struct('data',data_pdw,'fa',fa_pdw,'TR',tr_pdw,'B1',1),...
-%                             struct('data',data_t1w,'fa',fa_t1w,'TR',tr_t1w,'B1',1), true);
-%   R1_for_MTsat = hmri_calc_R1(struct('data',data_pdw,'fa',fa_pdw,'TR',tr_pdw,'B1',1),...
+%   Procedure from Helms (2008) correcting for B1 to second order within the small flip angle regime by setting B1 = 1:
+%     A_for_MTsat = hmri_calc_A(struct('data',data_pdw,'fa',fa_pdw,'TR',tr_pdw,'B1',1),...
 %                               struct('data',data_t1w,'fa',fa_t1w,'TR',tr_t1w,'B1',1), true);
-%   MTsat = hmri_calc_MTsat(struct('data',data_mtw,'fa',fa_mtw,'TR',tr_mtw,'B1',1), A_for_MTsat, R1_for_MTsat);
+%     R1_for_MTsat = hmri_calc_R1(struct('data',data_pdw,'fa',fa_pdw,'TR',tr_pdw,'B1',1),...
+%                                 struct('data',data_t1w,'fa',fa_t1w,'TR',tr_t1w,'B1',1), true);
+%     MTsat = hmri_calc_MTsat(struct('data',data_mtw,'fa',fa_mtw,'TR',tr_mtw,'B1',1), A_for_MTsat, R1_for_MTsat);
 %
 % References:
 %   Helms, et al. (2008), "High-resolution maps of magnetization transfer with inherent correction for RF inhomogeneity 

--- a/hmri_code_tests/hmri_MTsat_test.m
+++ b/hmri_code_tests/hmri_MTsat_test.m
@@ -1,0 +1,97 @@
+%% Main function to generate tests
+function tests = hmri_MTsat_test
+tests = functiontests(localfunctions);
+end
+
+%% Test Functions
+
+function typical3TprotocolTest(testCase)
+
+MTw.TR=23.7e-3; % s
+MTw.fa=deg2rad(6); % rad
+
+MTw=addDataFields(MTw,testCase.TestData.PD,testCase.TestData.R1,testCase.TestData.B1map,testCase.TestData.MTsat/100);
+
+MTsatEst=hmri_calc_MTsat(MTw, testCase.TestData.PD, testCase.TestData.R1);
+
+assertEqual(testCase,MTsatEst,testCase.TestData.MTsat,'AbsTol',testCase.TestData.tol,'Estimated MTsat has large error!')
+
+end
+
+function helmsB1correctionTest(testCase)
+
+MTsat=100*testCase.TestData.MTsat;
+B1=testCase.TestData.B1map;
+C=0.4;
+
+MTsatB1bias=MTsat.*(1-C.*B1)/(1-C);
+
+MTsatEst=hmri_correct_MTsat(MTsatB1bias, B1, 'helms', C);
+
+assertEqual(testCase,MTsatEst,MTsat,'AbsTol',testCase.TestData.tol,'Estimated MTsat has large error!')
+
+end
+
+function lippB1correctionTest(testCase)
+
+MTsat=testCase.TestData.MTsat;
+B1=testCase.TestData.B1map;
+C=1.2;
+
+MTsatB1bias=MTsat.*(1+C.*(B1-1));
+
+MTsatEst=hmri_correct_MTsat(MTsatB1bias, B1, 'lipp', C);
+
+assertEqual(testCase,MTsatEst,MTsat,'AbsTol',testCase.TestData.tol,'Estimated MTsat has large error!')
+
+end
+
+%% subfunctions
+function w=addDataFields(w,PD,R1,B1,delta)
+
+w.data=bsxfun(@times,PD,hmri_test_utils.HelmsMTwApprox(w.fa*B1,w.TR,R1,delta));
+w.B1=B1;
+
+end
+
+%% Optional file fixtures  
+function setupOnce(testCase)  % do not change function name
+% set a new path, for example
+end
+
+function teardownOnce(testCase)  % do not change function name
+% change back to original path, for example
+end
+
+%% Optional fresh fixtures  
+function setup(testCase)  % do not change function name
+
+% Reset random seed for reproducibility
+hmri_test_utils.seedRandomNumberGenerator;
+
+% Define reasonable parameter set
+dims=[20,50,30];
+
+R1min=0.5; % / s
+R1max=2; % / s
+testCase.TestData.R1=R1min+(R1max-R1min)*rand([dims,1]); % / s
+
+PDmin=500;
+PDmax=2000;
+testCase.TestData.PD=PDmin+(PDmax-PDmin)*rand([dims,1]);
+
+B1min=0.4;
+B1max=1.6;
+testCase.TestData.B1map=B1min+(B1max-B1min)*rand([dims,1]);
+
+MTsatMin=0.1;
+MTsatMax=2;
+testCase.TestData.MTsat=MTsatMin+(MTsatMax-MTsatMin)*rand([dims,1]);
+
+testCase.TestData.tol=1e-3*(MTsatMin+MTsatMax/2);
+
+end
+
+function teardown(testCase)  % do not change function name
+clear MTw MTsatEst MTsat MTsatB1bias B1 cfg_check_assignin
+end

--- a/hmri_code_tests/hmri_test_utils.m
+++ b/hmri_code_tests/hmri_test_utils.m
@@ -10,6 +10,19 @@ classdef hmri_test_utils
             S=sin(alpha).*(1-exp(-TR.*R1))./(1-cos(alpha).*exp(-TR.*R1));
             
         end
+
+        function S=HelmsMTwApprox(alpha,TR,R1,delta)
+            % Approximate steady state solution for dual flip angle GRE
+            % experiment where: 
+            %   1. the two pulses are approximately coincident
+            %   2. both flip angles alpha and beta are small, and 
+            %   3. beta is related to delta by delta = beta^2/2 ~ 1 - cos(beta).
+            % See Helms, et al. (MRM 2008 https://doi.org/10.1002/mrm.21732)
+            % for more details.
+            
+            S=(alpha.*TR.*R1)./(alpha.^2/2 + delta + TR.*R1);
+            
+        end
         
         % TODO: warn about activating legacy RNG
         function seedRandomNumberGenerator

--- a/hmri_correct_MTsat.m
+++ b/hmri_correct_MTsat.m
@@ -1,17 +1,49 @@
-function MTsat=hmri_correct_MTsat(MTsat,B1)
+function MTsat = hmri_correct_MTsat(MTsat, B1, model, C)
 %hmri_correct_MTsat Correct MTsat using B1 and a heuristic model.
 % 
 % Input:
-%   MTsat (array of MTsat estimates)
+%   MTsat (array of MTsat estimates in percent units [p.u.])
 %   B1    (array of B1 ratios: actual fa / nominal fa)
+%   model (either 'lipp' or 'helms' model)
+%   C     (parameter of heuristic model)
 %
 % Output:
-%   MTsat (in percent units [p.u.])
+%   MTsat (in p.u.)
 %
 % Examples:
+%   If using the Helms, et al. (2021) model, then the input MTsat needs to have been computed with B1=1:
+%     A_for_MTsat  = hmri_calc_A( struct('data',data_pdw,'fa',fa_pdw,'TR',tr_pdw,'B1',1), ...
+%                                 struct('data',data_t1w,'fa',fa_t1w,'TR',tr_t1w,'B1',1), true);
+%     R1_for_MTsat = hmri_calc_R1(struct('data',data_pdw,'fa',fa_pdw,'TR',tr_pdw,'B1',1), ...
+%                                 struct('data',data_t1w,'fa',fa_t1w,'TR',tr_t1w,'B1',1), true);
+%     MTsat = hmri_calc_MTsat(struct('data',data_mtw,'fa',fa_mtw,'TR',tr_mtw,'B1',1), A_for_MTsat, R1_for_MTsat);
+%   as the B1 correction then happens here:
+%     MTsat_corrected = hmri_correct_MTsat(MTsat, B1, 'helms', 0.4);
+%
+%   If using the Lipp, et al. (2023) model, then the input MTsat needs to have been computed with the real B1. Note
+%   that the T1w excitation flip angle was large in Lipp, et al. (2023), so the small angle approximation was not
+%   used when computing A and R1.
+%     A_for_MTsat  = hmri_calc_A( struct('data',data_pdw,'fa',fa_pdw,'TR',tr_pdw,'B1',B1), ...
+%                                 struct('data',data_t1w,'fa',fa_t1w,'TR',tr_t1w,'B1',B1), false);
+%     R1_for_MTsat = hmri_calc_R1(struct('data',data_pdw,'fa',fa_pdw,'TR',tr_pdw,'B1',B1), ...
+%                                 struct('data',data_t1w,'fa',fa_t1w,'TR',tr_t1w,'B1',B1), false);
+%     MTsat = hmri_calc_MTsat(struct('data',data_mtw,'fa',fa_mtw,'TR',tr_mtw,'B1',B1), A_for_MTsat, R1_for_MTsat);
+%     MTsat_corrected = hmri_correct_MTsat(MTsat, B1, 'lipp', 1.2);
+%
 % References:
+%   Helms, et al. (2021) "Correction of FLASH-based MT saturation in human brain for residual bias of B1-inhomogeneity at 3T"
+%       arXiv preprint. https://doi.org/10.48550/arXiv.2104.14878
+%   Lipp, et al. (2023). "B1+-correction of magnetization transfer saturation maps optimized for 7T postmortem MRI of the brain".
+%       Magn. Reson. Med. https://doi.org/10.1002/mrm.29524
 
-MTsat = MTsat .* (1 - 0.4) ./ (1 - 0.4 * B1);
+switch model
+    'helms'
+        MTsat = MTsat .* (1 - C) ./ (1 - C * B1);
+    'lipp'
+        MTsat = MTsat ./ (1 + C * (B1 - 1));
+    otherwise
+        error('unknown MTsat correction model %s. Allowed models are "helms" and "lipp"',model)
+end
 
 % Make data points with missing data NaN
 nanmask=(MTsat.data==0)|(MTsat.data==0);

--- a/hmri_correct_MTsat.m
+++ b/hmri_correct_MTsat.m
@@ -37,16 +37,16 @@ function MTsat = hmri_correct_MTsat(MTsat, B1, model, C)
 %       Magn. Reson. Med. https://doi.org/10.1002/mrm.29524
 
 switch model
-    'helms'
+    case 'helms'
         MTsat = MTsat .* (1 - C) ./ (1 - C * B1);
-    'lipp'
+    case 'lipp'
         MTsat = MTsat ./ (1 + C * (B1 - 1));
     otherwise
-        error('unknown MTsat correction model %s. Allowed models are "helms" and "lipp"',model)
+        error('unknown MTsat correction model ''%s''. Allowed models are ''helms'' and ''lipp''',model)
 end
 
 % Make data points with missing data NaN
-nanmask=(MTsat.data==0)|(MTsat.data==0);
+nanmask=(MTsat==0)|(MTsat==0);
 MTsat(nanmask)=NaN;
 
 end

--- a/hmri_correct_MTsat.m
+++ b/hmri_correct_MTsat.m
@@ -1,0 +1,21 @@
+function MTsat=hmri_correct_MTsat(MTsat,B1)
+%hmri_correct_MTsat Correct MTsat using B1 and a heuristic model.
+% 
+% Input:
+%   PDw and T1w are structs with the fields:
+%     MTsat (array of MTsat estimates)
+%     B1    (array of B1 ratios: actual fa / nominal fa)
+%
+% Output:
+%   MTsat (in percent units [p.u.])
+%
+% Examples:
+% References:
+
+MTsat = MTsat .* (1 - 0.4) ./ (1 - 0.4 * B1);
+
+% Make data points with missing data NaN
+nanmask=(MTsat.data==0)|(MTsat.data==0);
+MTsat(nanmask)=NaN;
+
+end

--- a/hmri_correct_MTsat.m
+++ b/hmri_correct_MTsat.m
@@ -2,9 +2,8 @@ function MTsat=hmri_correct_MTsat(MTsat,B1)
 %hmri_correct_MTsat Correct MTsat using B1 and a heuristic model.
 % 
 % Input:
-%   PDw and T1w are structs with the fields:
-%     MTsat (array of MTsat estimates)
-%     B1    (array of B1 ratios: actual fa / nominal fa)
+%   MTsat (array of MTsat estimates)
+%   B1    (array of B1 ratios: actual fa / nominal fa)
 %
 % Output:
 %   MTsat (in percent units [p.u.])

--- a/hmri_correct_MTsat.m
+++ b/hmri_correct_MTsat.m
@@ -45,8 +45,4 @@ switch model
         error('unknown MTsat correction model ''%s''. Allowed models are ''helms'' and ''lipp''',model)
 end
 
-% Make data points with missing data NaN
-nanmask=(MTsat==0)|(MTsat==0);
-MTsat(nanmask)=NaN;
-
 end

--- a/hmri_create_MTProt.m
+++ b/hmri_create_MTProt.m
@@ -1560,9 +1560,9 @@ if (mpm_params.T1widx && mpm_params.PDwidx && mpm_params.MTwidx)
         case 'lipp'
             mpm_params.MTsatB1CorrectionC = hmri_get_defaults('MTsatB1CorrectionLippC');
         otherwise
-            error('unknown MTsat B1 correction model %s. Allowed models are "helms" and "lipp"', mpm_params.MTsatB1CorrectionModel)
+            error('unknown MTsat B1 correction model ''%s''. Allowed models are ''helms'' and ''lipp''', mpm_params.MTsatB1CorrectionModel)
     end
-    hmri_log(sprintf('INFO: Using MTsat B1 correction model %s with C = %g.', mpm_params.MTsatB1CorrectionModel, mpm_params.MTsatB1CorrectionC), mpm_params.defflags);
+    hmri_log(sprintf('INFO: Using MTsat B1 correction model ''%s'' with C = %g.', mpm_params.MTsatB1CorrectionModel, mpm_params.MTsatB1CorrectionC), mpm_params.defflags);
 else
     mpm_params.qMT = 0;
 end

--- a/hmri_create_MTProt.m
+++ b/hmri_create_MTProt.m
@@ -669,27 +669,23 @@ for p = 1:dm(3)
             switch mpm_params.MTsatB1CorrectionModel
                 case 'helms' 
                     B1_mtw=1;
-                    R1_forMT = hmri_calc_R1(struct('data',PDw,'fa',fa_pdw_rad,'TR',TR_pdw,'B1',B1_mtw),...
-                        struct('data',T1w,'fa',fa_t1w_rad,'TR',TR_t1w,'B1',1),...
-                        mpm_params.small_angle_approx);
-                    R1_forMT(isnan(R1_forMT))=0;
-                    A_forMT = hmri_calc_A(struct('data',PDw,'fa',fa_pdw_rad,'TR',TR_pdw,'B1',B1_mtw),...
-                        struct('data',T1w_forA,'fa',fa_t1w_rad,'TR',TR_t1w,'B1',1),...
-                        mpm_params.small_angle_approx);
-                    A_forMT(isnan(A_forMT))=0;
                     if isempty(f_T)
                         hmri_log('WARNING: MTsat B1-correction using the Helms model was selected but no B1 map data was found. MTsat will only be corrected with the quadratic model from Helms, et al. (MRM 2008).', mpm_params.defflags)
                     end
                 case 'lipp'
                     B1_mtw=f_T;
-                    R1_forMT=R1*1e-6;
-                    A_forMT=A;
                     if isempty(f_T)
                         hmri_log('WARNING: MTsat B1-correction using the Lipp model was selected but no B1 map data was found. MTsat will not be B1 corrected.', mpm_params.defflags)
                     end
             end
-            
-            % MT in [p.u.]; offset by - famt * famt / 2 * 100 where MT_w = 0 (outside mask)
+
+            % MT in [p.u.]
+            A_forMT = hmri_calc_A(struct('data',PDw,'fa',fa_pdw_rad,'TR',TR_pdw,'B1',B1_mtw),...
+                struct('data',T1w_forA,'fa',fa_t1w_rad,'TR',TR_t1w,'B1',1),...
+                mpm_params.small_angle_approx);
+            R1_forMT = hmri_calc_R1(struct('data',PDw,'fa',fa_pdw_rad,'TR',TR_pdw,'B1',B1_mtw),...
+                struct('data',T1w,'fa',fa_t1w_rad,'TR',TR_t1w,'B1',1),...
+                mpm_params.small_angle_approx);
             MT = hmri_calc_MTsat(struct('data',MTw,'fa',fa_mtw_rad,'TR',TR_mtw,'B1',B1_mtw), A_forMT, R1_forMT);
 
             % f_T correction is applied either if:

--- a/hmri_create_MTProt.m
+++ b/hmri_create_MTProt.m
@@ -674,19 +674,21 @@ for p = 1:dm(3)
                 mpm_params.small_angle_approx);
             A_forMT(isnan(A_forMT))=0;
             
+            B1_mtw=1;
+            
             % MT in [p.u.]; offset by - famt * famt / 2 * 100 where MT_w = 0 (outside mask)
-            MT  = ( (A_forMT * fa_mtw_rad - MTw) ./ (MTw+eps) .* R1_forMT*TR_mtw - fa_mtw_rad^2 / 2 ) * 100;
+            MT = hmri_calc_MTsat(struct('data',MTw,'fa',fa_mtw_rad,'TR',TR_mtw,'B1',B1_mtw),...
+                A_forMT,R1_forMT);
             % f_T correction is applied either if:
             % - f_T has been provided as separate B1 mapping measurement (not
             % UNICORT!) or
             % - f_T has been calculated using UNICORT *AND* the UNICORT.MT flag
             % is enabled (advanced user only! method not validated yet!)
             if (~isempty(f_T))&&(~mpm_params.UNICORT.R1 || mpm_params.UNICORT.MT)
-                MT = MT .* (1 - 0.4) ./ (1 - 0.4 * f_T);
+                MT = hmri_correct_MTsat(MT,f_T);
             end
             
-            tmp      = MT;
-            Nmap(mpm_params.qMT).dat(:,:,p) = max(min(tmp,threshall.MT),-threshall.MT);
+            Nmap(mpm_params.qMT).dat(:,:,p) = max(min(MT,threshall.MT),-threshall.MT);
         end
     
     end

--- a/hmri_create_MTProt.m
+++ b/hmri_create_MTProt.m
@@ -677,17 +677,17 @@ for p = 1:dm(3)
             B1_mtw=1;
             
             % MT in [p.u.]; offset by - famt * famt / 2 * 100 where MT_w = 0 (outside mask)
-            MT = hmri_calc_MTsat(struct('data',MTw,'fa',fa_mtw_rad,'TR',TR_mtw,'B1',B1_mtw),...
-                A_forMT,R1_forMT);
+            MT = hmri_calc_MTsat(struct('data',MTw,'fa',fa_mtw_rad,'TR',TR_mtw,'B1',B1_mtw), A_forMT, R1_forMT);
             % f_T correction is applied either if:
             % - f_T has been provided as separate B1 mapping measurement (not
             % UNICORT!) or
             % - f_T has been calculated using UNICORT *AND* the UNICORT.MT flag
             % is enabled (advanced user only! method not validated yet!)
             if (~isempty(f_T))&&(~mpm_params.UNICORT.R1 || mpm_params.UNICORT.MT)
-                MT = hmri_correct_MTsat(MT,f_T);
+                MT = hmri_correct_MTsat(MT,f_T,'helms',0.4);
             end
-            
+
+            MT(isnan(MT))=0;
             Nmap(mpm_params.qMT).dat(:,:,p) = max(min(MT,threshall.MT),-threshall.MT);
         end
     


### PR DESCRIPTION
Work towards refactoring MTprot to make it more testable. 

This also allowed the MTsat correction model from Lipp, et al., (2023, B1+-correction of magnetization transfer saturation maps optimized for 7T postmortem MRI of the brain. Magn Reson Med.; 89:1385-1400. doi:[10.1002/mrm.29524](https://doi.org/10.1002/mrm.29524)) to be added.