### PR TITLE
Fix floating point comparison when selecting imperfect spoiling correction protocol

### DIFF
--- a/hmri_create_MTProt.m
+++ b/hmri_create_MTProt.m
@@ -1249,7 +1249,9 @@ if mpm_params.PDwidx && mpm_params.T1widx && ISC
     ii = 0; mtch = false;
     while ~mtch && ii < nsets
         ii = ii+1;
-        if all(MPMacq_prot == MPMacq_sets.vals{ii})
+        % don't check exact equality, but equality to within certain amount
+        % of floating point error
+        if all(abs(MPMacq_prot - MPMacq_sets.vals{ii}) < 5*eps(MPMacq_prot))
             mtch  = true;
             prot_tag = MPMacq_sets.tags{ii};
             hmri_log(sprintf(['INFO: MPM acquisition protocol = %s.' ...


### PR DESCRIPTION
The test for whether protocols matched for imperfect spoiling correction used exact floating point comparison, which means that some protocols are not matched because they differ in some tiny fraction of the TR, although this difference is actually unimportant. I have added a small tolerance to the comparison to avoid this happening.