### PR TITLE
Copy acquisition metadata to extrapolated weighted images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This changelog documents all notable changes to the hMRI-toolbox.
 Most recent version numbers *should* follow the [Semantic Versioning](https://semver.org/spec/v2.0.0.html) principles (e.g. bug fixes: x.x.1 > x.x.2, new feature with backward compatibility: x.2.x > x.3.0, major release affecting the way data are handled and processed: 1.x.x > 2.0.0).
 
 ## [unreleased]
+### Added
+- copy acquisition metadata to TE=0 volumes in Results/Supplementary folder after map creation so they can be used as input to the toolbox if needed
 
 ## [v0.6.0]
 ### Added

--- a/hmri_create_MTProt.m
+++ b/hmri_create_MTProt.m
@@ -392,11 +392,18 @@ if mpm_params.proc.R2sOLS && any(mpm_params.estaticsR2s)
                 Ni = hmri_create_nifti(Pte0{ccon}, V_pdw(1), dt, ...
                     sprintf('%s fit to TE=0 for %sw images - %d echoes', mpm_params.R2s_fit_method, mpm_params.input(ccon).tag, length(mpm_params.input(ccon).TE)));
                                 
-                % set metadata
+                % store processing history in metadata
                 input_files = mpm_params.input(ccon).fnam;
                 Output_hdr = init_mpm_output_metadata(input_files, mpm_params);
                 Output_hdr.history.output.imtype = Ni.descrip;
                 Output_hdr.history.output.units = 'a.u.';
+
+                % copy acquisition metadata so extrapolated data could be fed back into 
+                % the toolbox if needed
+                Output_hdr.acqpar = struct('RepetitionTime',mpm_params.input(ccon).TR, ...
+                    'EchoTime',0, ...
+                    'FlipAngle',mpm_params.input(ccon).fa);
+
                 set_metadata(Pte0{ccon},Output_hdr,mpm_params.json);
                 
                 % re-load the updated NIFTI file (in case extended header has


### PR DESCRIPTION
It can be convenient to use the weighted images extrapolated to TE 0 when re-running the toolbox to avoid having to also re-run the R2* fitting and registration. However the necessary metadata for this is not currently stored in the sidecar files of the images. This oversight is rectified by this pull request.

The implementation was copied from similar code in the RFsens calculation code ([here](https://github.com/hMRI-group/hMRI-toolbox/blob/54a3efe289ab3725e84cd72523b7783ac1ee84da/hmri_create_RFsens.m#L85-L87)).

I've tested the implementation using part of the demo dataset (the PDw and T1w data), showing that the normal map creation pipeline still works, that the acquisition parameters are indeed stored in the extrapolated data, and that the extrapolated data can then be used to re-run the toolbox.