### PR TITLE
Fix deprecation of MATLAB datestr syntax in hMRI logging

### DIFF
--- a/hmri_create_MTProt.m
+++ b/hmri_create_MTProt.m
@@ -86,7 +86,7 @@ function [fR1, fR2s, fMT, fA, PPDw, PT1w, PMTw]  = hmri_create_MTProt(jobsubj) %
 
 flags = jobsubj.log.flags;
 flags.PopUp = false;
-hmri_log(sprintf('\t============ MPM PROCESSING - %s.m (%s) ============', mfilename, datestr(now)),flags);
+hmri_log(sprintf('\t============ MPM PROCESSING - %s.m (%s) ============', mfilename, datetime('now')),flags);
 
 % retrieves all required parameters for MPM processing
 mpm_params = get_mpm_params(jobsubj);
@@ -959,7 +959,7 @@ spm_jsonwrite(fullfile(supplpath,'hMRI_map_creation_mpm_params.json'),mpm_params
 
 spm_progress_bar('Clear');
 
-hmri_log(sprintf('\t============ MPM PROCESSING: completed (%s) ============', datestr(now)),mpm_params.nopuflags);
+hmri_log(sprintf('\t============ MPM PROCESSING: completed (%s) ============', datetime('now')),mpm_params.nopuflags);
 
 
 end

--- a/hmri_create_RFsens.m
+++ b/hmri_create_RFsens.m
@@ -22,7 +22,7 @@ function jobsubj = hmri_create_RFsens(jobsubj)
 
 flags = jobsubj.log.flags;
 flags.PopUp = false;
-hmri_log(sprintf('\t============ RF SENSITIVITY CORRECTION - %s.m (%s) ============', mfilename, datestr(now)),flags);
+hmri_log(sprintf('\t============ RF SENSITIVITY CORRECTION - %s.m (%s) ============', mfilename, datetime('now')),flags);
 
 %==========================================================================
 % Define processing parameters, defaults, input files...
@@ -102,7 +102,7 @@ end
 % save RF sensitivity processing parameters
 spm_jsonwrite(fullfile(supplpath,'hMRI_map_creation_rfsens_params.json'),rfsens_params,struct('indent','\t'));
 
-hmri_log(sprintf('\t============ RF SENSITIVITY CORRECTION: completed (%s) ============', datestr(now)),rfsens_params.nopuflags);
+hmri_log(sprintf('\t============ RF SENSITIVITY CORRECTION: completed (%s) ============', datetime('now')),rfsens_params.nopuflags);
 
 end
 

--- a/hmri_create_b1map.m
+++ b/hmri_create_b1map.m
@@ -20,7 +20,7 @@ function P_trans = hmri_create_b1map(jobsubj)
 
 flags = jobsubj.log.flags;
 flags.PopUp = false;
-hmri_log(sprintf('\t============ CREATE B1 MAP - %s.m (%s) ============', mfilename, datestr(now)),flags);
+hmri_log(sprintf('\t============ CREATE B1 MAP - %s.m (%s) ============', mfilename, datetime('now')),flags);
 
 % retrieve effective acquisition & processing parameters, alternatively
 % use defaults
@@ -107,7 +107,7 @@ if ~isempty(P_trans)
     P_trans = char(P_trans_copy{1},P_trans_copy{2});
 end
 
-hmri_log(sprintf('\t============ CREATE B1 MAP: completed (%s) ============', datestr(now)),b1map_params.nopuflags);
+hmri_log(sprintf('\t============ CREATE B1 MAP: completed (%s) ============', datetime('now')),b1map_params.nopuflags);
 
 end
 
@@ -643,7 +643,7 @@ b1map_params.defflags = jobsubj.log.flags; % default flags
 b1map_params.nopuflags = jobsubj.log.flags; % force no Pop-Up
 b1map_params.nopuflags.PopUp = false;
 
-hmri_log(sprintf('\t------------ B1 MAP CALCULATION (%s) %s ------------',b1_protocol, datestr(now)),b1map_params.nopuflags);
+hmri_log(sprintf('\t------------ B1 MAP CALCULATION (%s) %s ------------',b1_protocol, datetime('now')),b1map_params.nopuflags);
 
 % save SPM version (slight differences may appear in the results depending
 % on the SPM version!)

--- a/hmri_create_unicort.m
+++ b/hmri_create_unicort.m
@@ -34,7 +34,7 @@ flags.def = jobsubj.log.flags; % default flags
 flags.nopu = jobsubj.log.flags; % force no Pop-Up
 flags.nopu.PopUp = false; 
 
-hmri_log(sprintf('\t============ UNICORT: CORRECT R1 MAPS FOR B1+ BIAS - %s.m (%s) ============', mfilename, datestr(now)),flags.nopu);
+hmri_log(sprintf('\t============ UNICORT: CORRECT R1 MAPS FOR B1+ BIAS - %s.m (%s) ============', mfilename, datetime('now')),flags.nopu);
 
 % json metadata default options
 json = hmri_get_defaults('json');
@@ -178,7 +178,7 @@ try copyfile([spm_str_manip(P_B1,'r') '.json'],[spm_str_manip(out.B1u{1},'r') '.
 % save unicort params as json-file
 spm_jsonwrite(fullfile(supplpath, 'hMRI_map_creation_unicort_params.json'),unicort_params,struct('indent','\t'));
 
-hmri_log(sprintf('\t============ UNICORT: completed (%s) ============', datestr(now)),flags.nopu);
+hmri_log(sprintf('\t============ UNICORT: completed (%s) ============', datetime('now')),flags.nopu);
 
 end
 

--- a/hmri_run_create.m
+++ b/hmri_run_create.m
@@ -101,7 +101,7 @@ job.subj.log.flags = struct('LogFile',struct('Enabled',true,'FileName','hMRI_map
     'PopUp',job.subj.popup,'ComWin',true);
 flags = job.subj.log.flags;
 flags.PopUp = false;
-hmri_log(sprintf('\t============ CREATE hMRI MAPS MODULE - %s.m (%s) ============', mfilename, datestr(now)),flags);
+hmri_log(sprintf('\t============ CREATE hMRI MAPS MODULE - %s.m (%s) ============', mfilename, datetime('now')),flags);
 
 if newrespath
     hmri_log(sprintf(['WARNING: existing results from previous run(s) were found, \n' ...
@@ -150,6 +150,6 @@ end
 f = fopen(fullfile(respath, '_finished_'), 'wb');
 fclose(f);
 
-hmri_log(sprintf('\t============ CREATE hMRI MAPS MODULE: completed (%s) ============', datestr(now)),flags);
+hmri_log(sprintf('\t============ CREATE hMRI MAPS MODULE: completed (%s) ============', datetime('now')),flags);
 
 end

--- a/hmri_run_create_B1.m
+++ b/hmri_run_create_B1.m
@@ -74,7 +74,7 @@ job.subj.log.flags = struct('LogFile',struct('Enabled',true,'FileName','hMRI_B1_
     'PopUp',job.subj.popup,'ComWin',true);
 flags = job.subj.log.flags;
 flags.PopUp = false;
-hmri_log(sprintf('\t============ CREATE B1 MAP MODULE - %s.m (%s) ============', mfilename, datestr(now)),flags);
+hmri_log(sprintf('\t============ CREATE B1 MAP MODULE - %s.m (%s) ============', mfilename, datetime('now')),flags);
 
 if newrespath
     hmri_log(sprintf(['WARNING: existing results from previous run(s) were found, \n' ...
@@ -108,6 +108,6 @@ end
 f = fopen(fullfile(respath, '_finished_'), 'wb');
 fclose(f);
 
-hmri_log(sprintf('\t============ CREATE B1 MAP MODULE: completed (%s) ============', datestr(now)),flags);
+hmri_log(sprintf('\t============ CREATE B1 MAP MODULE: completed (%s) ============', datetime('now')),flags);
 
 end


### PR DESCRIPTION
It is now [discouraged](https://mathworks.com/help/matlab/matlab_prog/replace-discouraged-instances-of-serial-date-numbers-and-date-strings.html) to use `datestr(now)` to get a string of the current time. This syntax was used throughout the toolbox to log the current time. I have replaced this with the MATLAB-recommended replacement `datetime('now')` and have tested that this replacement still works on our [earliest supported MATLAB version, 9.4](https://github.com/hMRI-group/hMRI-toolbox/wiki/GetStarted#software-requirements).