### PR TITLE
Fix B1 map creation crash when no sidecar files present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Most recent version numbers *should* follow the [Semantic Versioning](https://se
 ## [unreleased]
 ### Fixed
 - function-evaluate SPM-struct (preproc8.val) for SPM development version compatibility.
+- make B1-map creation using 3DEPI SE/STE and AFI methods fall back to defaults without sidecar files, rather than crash
 
 ### Added
 - copy acquisition metadata to TE=0 volumes in Results/Supplementary folder after map creation so they can be used as input to the toolbox if needed

--- a/hmri_create_b1map.m
+++ b/hmri_create_b1map.m
@@ -702,7 +702,7 @@ switch b1_protocol
         if ~isempty(b1map_params.b1input)
             hmri_log(sprintf('SE/STE EPI protocol selected ...'),b1map_params.nopuflags);
             b1hdr = get_metadata(b1map_params.b1input(1,:));
-            if isempty(b1hdr) % no sidecar file with metadata
+            if isempty(b1hdr{1}) % no sidecar file with metadata
                 b1hdr{1} = b1map_params.b1input(1,:); 
             end 
 
@@ -923,7 +923,7 @@ switch b1_protocol
         if ~isempty(b1map_params.b1input)
             hmri_log(sprintf('AFI protocol selected ...'),b1map_params.nopuflags);
             b1hdr = get_metadata(b1map_params.b1input);
-            if isempty(b1hdr) % no sidecar file with metadata
+            if isempty(b1hdr{1}) % no sidecar file with metadata
                 b1hdr{1} = b1map_params.b1input(1,:);
                 b1hdr{2} = b1map_params.b1input(2,:);
             end

--- a/hmri_create_b1map.m
+++ b/hmri_create_b1map.m
@@ -702,6 +702,9 @@ switch b1_protocol
         if ~isempty(b1map_params.b1input)
             hmri_log(sprintf('SE/STE EPI protocol selected ...'),b1map_params.nopuflags);
             b1hdr = get_metadata(b1map_params.b1input(1,:));
+            if isempty(b1hdr) % no sidecar file with metadata
+                b1hdr{1} = b1map_params.b1input(1,:); 
+            end 
 
             V = spm_vol(b1map_params.b1input);
 
@@ -713,7 +716,7 @@ switch b1_protocol
             % assumes conventional hMRI toolbox order as default but checks this order
             % when echo times are defined and b1validation.checkTEs is true
             % Echo times for input validation
-            tmp = get_metadata_val(b1hdr{1},'EchoTime');
+            tmp = get_metadata_val(b1map_params.b1input(1,:),'EchoTime');
             b1map_params.b1acq.EchoTimes=[];
             if b1map_params.b1validation.checkTEs
                 if isempty(tmp)
@@ -920,6 +923,10 @@ switch b1_protocol
         if ~isempty(b1map_params.b1input)
             hmri_log(sprintf('AFI protocol selected ...'),b1map_params.nopuflags);
             b1hdr = get_metadata(b1map_params.b1input);
+            if isempty(b1hdr) % no sidecar file with metadata
+                b1hdr{1} = b1map_params.b1input(1,:);
+                b1hdr{2} = b1map_params.b1input(2,:);
+            end
 
             try
                 tr1 = get_metadata_val(b1hdr{1},'RepetitionTime');

--- a/spm12/metadata/get_metadata_val_header.m
+++ b/spm12/metadata/get_metadata_val_header.m
@@ -33,6 +33,8 @@ function [parValue, parLocation] = get_metadata_val_header(varargin)
           fprintf(1,'Parameter available in NIFTI description field:\n\t%s = %5.2f deg\n', inParName, parValue{1});
             
         otherwise
+          parLocation = [];
+          parValue = [];
           fprintf(1,'Not able to retrieve any value for parameter %s.\n', inParName);
       end
     end


### PR DESCRIPTION
The 3D-EPI SE/STE and AFI methods currently crash if the input data do not have associated json sidecar files (or extended nii headers). The expected behaviour would be to fall back to the defaults specified in the [B1-defaults file](https://github.com/hMRI-group/hMRI-toolbox/wiki/DefaultsAndCustomization#customize-b1-mapping-acquisition-and-processing-parameters).

I've made some (in my opinion) minimally invasive changes to make falling back to the defaults work, but we should check carefully that there are no unintended consequences.