### PR TITLE
display warning message when contrasts have unmatching dimension

### DIFF
--- a/hmri_create_MTProt.m
+++ b/hmri_create_MTProt.m
@@ -1175,6 +1175,16 @@ else
 end 
 mpm_params.ncon = ccon; % number of contrasts available
 
+% Throw a warning if the contrasts PDw, MTw and T1w have non-matching
+% dimensions
+raw = cat(1, jobsubj.raw_mpm.MT, jobsubj.raw_mpm.PD, jobsubj.raw_mpm.T1);
+rawvol = spm_vol(raw);
+rawvolstruct = cat(1, rawvol{:});
+sts = spm_check_orientations(rawvolstruct);
+if ~sts
+    LogMsg = sprintf('%s\n\t- WARNING: MTw, PDw and T1w images have non-matching dimensions',LogMsg);
+end
+
 % Message displayed as pop-up if enabled since it is an important
 % information 
 hmri_log(LogMsg, mpm_params.defflags);


### PR DESCRIPTION
Dear @lukeje , this branch already implements the part that displays the warning message (which was already implemented and pushed before and is independent of the other changes), when contrasts with unmatching dimensions is fed to the toolbox.

you can either add the rest of the code (add your commits) to this branch directly  or you can simply hard-code your branch 
[FIX_differentcontrastsacqmat](https://github.com/hMRI-group/hMRI-toolbox/tree/FIX_differentcontrastsacqmat)
as we discussed.  

I will test and merge both branches (and delete both) when they are both conflict free to the current  (tested) master. Thank you.

