### PR TITLE
Fix 3D-EPI B1 mapping not using b1defaults for Triotim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Most recent version numbers *should* follow the [Semantic Versioning](https://se
 - Modify the filenames as files are copied to RFsensCalc to prevent overwriting in further processing
 - batch interface now enforces the number of B1 input images correctly for B1 mapping methods which only need two images
 - more informative error if optimization toolbox not present during NLLS R2* calculation
+- fix 3D-EPI B1 mapping not using b1defaults for Triotim scanner
 
 ## [v0.6.1]
 ### Fixed

--- a/spm12/metadata/get_metadata_val_classic.m
+++ b/spm12/metadata/get_metadata_val_classic.m
@@ -804,7 +804,10 @@ switch inParName
                         parValue{cRes} = 230:-10:0;
                     elseif contains(valMODELNAME,'7T','IgnoreCase',true)
                         parLocation{cRes} = [nam{1} '.adFree(3:4)'];
-                        parValue{cRes} = val{1}.adFree(3):-val{1}.adFree(4):0;      
+                        parValue{cRes} = val{1}.adFree(3):-val{1}.adFree(4):0;
+                    elseif contains(valMODELNAME,'TrioTim','IgnoreCase',true)
+                        parLocation{cRes} = [];
+                        parValue{cRes} = [];
                     else
                         parLocation{cRes}=[];
                     end

--- a/spm12/metadata/get_metadata_val_classic.m
+++ b/spm12/metadata/get_metadata_val_classic.m
@@ -805,11 +805,8 @@ switch inParName
                     elseif contains(valMODELNAME,'7T','IgnoreCase',true)
                         parLocation{cRes} = [nam{1} '.adFree(3:4)'];
                         parValue{cRes} = val{1}.adFree(3):-val{1}.adFree(4):0;
-                    elseif contains(valMODELNAME,'TrioTim','IgnoreCase',true)
-                        parLocation{cRes} = [];
-                        parValue{cRes} = [];
                     else
-                        parLocation{cRes}=[];
+                        fprintf(1,'\nWARNING: B1mapping version unknown (%s/%s). Give up guessing FA values.\n', valSEQ, valPROT);
                     end
                 otherwise
                     fprintf(1,'\nWARNING: B1mapping version unknown (%s/%s). Give up guessing FA values.\n', valSEQ, valPROT);

--- a/spm12/metadata/get_metadata_val_classic.m
+++ b/spm12/metadata/get_metadata_val_classic.m
@@ -807,7 +807,7 @@ switch inParName
                         parValue{cRes} = val{1}.adFree(3):-val{1}.adFree(4):0;
                     else
                         %Ensure B1 mapping falls back to defaults if scanner not recognised
-                        fprintf(1,'\nWARNING: B1mapping version unknown (%s/%s). Give up guessing FA values.\n', valSEQ, valPROT);
+                        fprintf(1,'\nWARNING: B1mapping version (%s/%s) unknown for scanner %s. Give up guessing FA values.\n', valSEQ, valPROT, valMODELNAME);
                     end
                 otherwise
                     fprintf(1,'\nWARNING: B1mapping version unknown (%s/%s). Give up guessing FA values.\n', valSEQ, valPROT);

--- a/spm12/metadata/get_metadata_val_classic.m
+++ b/spm12/metadata/get_metadata_val_classic.m
@@ -806,6 +806,7 @@ switch inParName
                         parLocation{cRes} = [nam{1} '.adFree(3:4)'];
                         parValue{cRes} = val{1}.adFree(3):-val{1}.adFree(4):0;
                     else
+                        %Ensure B1 mapping falls back to defaults if scanner not recognised
                         fprintf(1,'\nWARNING: B1mapping version unknown (%s/%s). Give up guessing FA values.\n', valSEQ, valPROT);
                     end
                 otherwise


### PR DESCRIPTION
This PR is inspired by a user query regarding the B1 map creation not falling back to the defaults for the Triotim protocol.  