### PR TITLE
Define global popups flag (as user input in GUI) to pass to all functions down the processing

### DIFF
--- a/hmri_calc_R2s.m
+++ b/hmri_calc_R2s.m
@@ -199,7 +199,7 @@ switch lower(method)
         end
     otherwise
         hmri_log([' ERROR: ' 'method ' method ' not recognised'],hmri_popupFlag);
-        error(['method ' method ' not recognised'])
+        error('hmri:MissingR2Method', ['method ' method ' not recognised'])
 end
 
 %% Output

--- a/hmri_calc_R2s.m
+++ b/hmri_calc_R2s.m
@@ -165,9 +165,10 @@ switch lower(method)
         ver_status = any(ismember(versionCell, 'Optimization Toolbox'));
         [license_status,~] = license('checkout', 'Optimization_toolbox');
         if ver_status==0 || license_status==0
-            hmri_log([' ERROR: ' 'optimization toolbox is missing: see error message for more details'],hmri_popupFlag);
-            error('hmri:NoOptimToolbox', "The methods 'nlls_ols','nlls_wls1','nlls_wls2','nlls_wls3' require Optimization Toolbox: either this toolbox and/or its license is missing." + ...
-                " Please use another method which does not need the Optimization Toolbox such as 'ols','wls1','wls2','wls3'. ")
+            err_string= "The methods 'nlls_ols','nlls_wls1','nlls_wls2','nlls_wls3' require Optimization Toolbox: either this toolbox and/or its license is missing." + ...
+                " Please use another method which does not need the Optimization Toolbox such as 'ols','wls1','wls2','wls3'. ";
+            hmri_log(char(strcat("ERROR: ", err_string)),hmri_popupFlag);
+            error('hmri:NoOptimToolbox', err_string)
         end
 
         % Check for NLLS case, where specification of the log-linear

--- a/hmri_calc_R2s.m
+++ b/hmri_calc_R2s.m
@@ -82,7 +82,8 @@ function [R2s,extrapolated,SError]=hmri_calc_R2s(weighted_data,method)
 %     group level sensitivity." 
 %     https://doi.org/10.1016/j.neuroimage.2022.119529
 
-
+% init global popup flag to get access to it
+global hmri_popupFlag;
 
 assert(isstruct(weighted_data),'hmri:structError',['inputs must be structs; see help ' mfilename])
 
@@ -164,6 +165,7 @@ switch lower(method)
         ver_status = any(ismember(versionCell, 'Optimization Toolbox'));
         [license_status,~] = license('checkout', 'Optimization_toolbox');
         if ver_status==0 || license_status==0
+            hmri_log([' ERROR: ' 'optimization toolbox is missing: see error message for more details'],hmri_popupFlag);
             error('hmri:NoOptimToolbox', "The methods 'nlls_ols','nlls_wls1','nlls_wls2','nlls_wls3' require Optimization Toolbox: either this toolbox and/or its license is missing." + ...
                 " Please use another method which does not need the Optimization Toolbox such as 'ols','wls1','wls2','wls3'. ")
         end
@@ -195,6 +197,7 @@ switch lower(method)
             beta(:,n)=lsqcurvefit(@(x,D)expDecay(x,D),beta0(:,n),D,y(:,n),[],[],opt);
         end
     otherwise
+        hmri_log([' ERROR: ' 'method ' method ' not recognised'],hmri_popupFlag);
         error(['method ' method ' not recognised'])
 end
 

--- a/hmri_run_create.m
+++ b/hmri_run_create.m
@@ -107,6 +107,12 @@ job.subj.log.flags = struct('LogFile',struct('Enabled',true,'FileName','hMRI_map
     'PopUp',job.subj.popup,'ComWin',true);
 flags = job.subj.log.flags;
 flags.PopUp = false;
+
+% introduce global popup flag for use of other functions further down 
+% the processing
+global hmri_popupFlag;
+hmri_popupFlag = job.subj.log.flags;
+
 hmri_log(sprintf('\t============ CREATE hMRI MAPS MODULE - %s.m (%s) ============', mfilename, datetime('now')),flags);
 
 if newrespath


### PR DESCRIPTION
## Description
the pop up flag `job.subj.log.flags` is set on the GUI and is `independent` of what functions are called down the processing. Currently, each time one needs to record an error to hmri_log along with a popup (as set on the GUI), the specific `job.subj.log.flags` needs to be passed to the function in some way every single time.  We solve this problem by extracting this user input within `hmri_run_create` into a global variable and then using this global variable directly to record the error messages within the `hmri_calc_R2s`.   We will be searching within the toolbox and using this method to implement all the error handling in the following format:
```
hmri_log(<error message>, <corresponding global popup flag as initialized in the associated hmri_run>)
error(<error message>)
``` 

observe that for instance these particular lines did not comply with the above, before the implementation here:
https://github.com/hMRI-group/hMRI-toolbox/blob/61238260649838d45a24c445c1b1a958e31b56d5/hmri_calc_R2s.m#L167
https://github.com/hMRI-group/hMRI-toolbox/blob/61238260649838d45a24c445c1b1a958e31b56d5/hmri_calc_R2s.m#L198

## Tests performed
The following shows the content of the hmri_log file during manual testing for the implemented errors:

```
...
(1) R1 map [s-1] (R1)
 - no Imperfect Spoiling Correction applied
 - B1+ bias correction using provided B1 map (pre_processed_B1)
 - no RF sensitivity bias correction

(2) A map (signal amplitude) [a.u.] (A)
 - no WM calibration
 - B1+ bias correction using provided B1 map (pre_processed_B1)
 - no RF sensitivity bias correction
 - R2* bias accounted for by TE=0 extrapolation (fullOLS option)

(3) MT saturation map [p.u.] (MTsat)
 - B1+ bias correction using provided B1 map (pre_processed_B1)
 - no RF sensitivity bias correction

(4) Classic MTR image [a.u.] - not currently saved in Results (MTR)

(5) R2* map [s-1] (R2s)
 - ESTATICS model (R2* map calculation)
 - B1+ bias correction does not apply
 - no RF sensitivity bias correction

	-------- R2* map calculation (basic exponential decay) --------

INFO: minimum number of echoes required for R2* map calculation is 4.
Number of PDw echoes available: 8

ERROR: The methods 'nlls_ols','nlls_wls1','nlls_wls2','nlls_wls3' require Optimization Toolbox: either this toolbox and/or its license is missing. Please use another method which does not need the Optimization Toolbox such as 'ols','wls1','wls2','wls3'. 

```


```
...
 - B1+ bias correction using provided B1 map (pre_processed_B1)
 - no RF sensitivity bias correction

(2) A map (signal amplitude) [a.u.] (A)
 - no WM calibration
 - B1+ bias correction using provided B1 map (pre_processed_B1)
 - no RF sensitivity bias correction
 - R2* bias accounted for by TE=0 extrapolation (fullOLS option)

(3) MT saturation map [p.u.] (MTsat)
 - B1+ bias correction using provided B1 map (pre_processed_B1)
 - no RF sensitivity bias correction

(4) Classic MTR image [a.u.] - not currently saved in Results (MTR)

(5) R2* map [s-1] (R2s)
 - ESTATICS model (R2* map calculation)
 - B1+ bias correction does not apply
 - no RF sensitivity bias correction

	-------- R2* map calculation (basic exponential decay) --------

INFO: minimum number of echoes required for R2* map calculation is 4.
Number of PDw echoes available: 8

 ERROR: method dontkonw not recognised
```