### PR TITLE
Fix when no TE provided in 3DEPI SE/STE B1 mapping data

### DIFF
--- a/hmri_create_B1Map_unwarp.m
+++ b/hmri_create_B1Map_unwarp.m
@@ -46,8 +46,10 @@ IP.uflags.pad = pm_defs.PAD;
 IP.uflags.ws = pm_defs.WS;
 IP.uflags.etd = IP.et{2}-IP.et{1};
 
-% default brain extraction parameters (mflags) 
-IP.mflags.template = pm_defs.MFLAGS.TEMPLATE;
+% default brain extraction parameters (mflags)
+if isfield(pm_defs.MFLAGS,'TEMPLATE') % 'TEMPLATE' field no longer defined in pm_defs in the spm25 FieldMap toolbox
+    IP.mflags.template = pm_defs.MFLAGS.TEMPLATE;
+end
 IP.mflags.fwhm = pm_defs.MFLAGS.FWHM; 
 IP.mflags.nerode = pm_defs.MFLAGS.NERODE;
 IP.mflags.ndilate = pm_defs.MFLAGS.NDILATE;

--- a/spm12/metadata/get_metadata_val_header.m
+++ b/spm12/metadata/get_metadata_val_header.m
@@ -1,44 +1,48 @@
 function [parValue, parLocation] = get_metadata_val_header(varargin)
-  % there seems to be no metadata available (mstruc is not a structure
-  % and is likely to be empty). Still try a few tricks in case either
-  % TR/TE/FA is the target field and available in the description field:
-  inParName = varargin{2};
-  if ischar(varargin{1}) && strcmp(spm_file(varargin{1},'ext'),'nii')
+% there seems to be no metadata available (mstruc is not a structure
+% and is likely to be empty). Still try a few tricks in case either
+% TR/TE/FA is the target field and available in the description field:
+inParName = varargin{2};
+if ischar(varargin{1}) && strcmp(spm_file(varargin{1},'ext'),'nii')
     fnam = varargin{1};
     fprintf(1,'\nWARNING: No metadata available in %s.\n', fnam);
     N = nifti(fnam);
     p = struct('tr',[],'te',[],'fa',[]);
     tmp = regexp(N.descrip,'TR=(?<tr>.+)ms/TE=(?<te>.+)ms/FA=(?<fa>.+)deg','names');
     if ~isempty(tmp)
-      p.tr = str2double(tmp.tr);
-      p.te = str2double(tmp.te);
-      p.fa = str2double(tmp.fa);
-      switch inParName
-        case 'RepetitionTime' % [ms]
-          cRes = 1;
-          parLocation{cRes} = 'NiftiDescriptionField';
-          parValue{cRes} = p.tr;
-          fprintf(1,'Parameter available in NIFTI description field:\n\t%s = %5.2f ms\n', inParName, parValue{1});
-            
-        case 'EchoTime'
-          cRes = 1;
-          parLocation{cRes} = 'NiftiDescriptionField';
-          parValue{cRes} = p.te;
-          fprintf(1,'Parameter available in NIFTI description field:\n\t%s = %5.2f ms\n', inParName, parValue{1});
-            
-        case 'FlipAngle'
-          cRes = 1;
-          parLocation{cRes} = 'NiftiDescriptionField';
-          parValue{cRes} = p.fa;
-          fprintf(1,'Parameter available in NIFTI description field:\n\t%s = %5.2f deg\n', inParName, parValue{1});
-            
-        otherwise
-          parLocation = [];
-          parValue = [];
-          fprintf(1,'Not able to retrieve any value for parameter %s.\n', inParName);
-      end
+        p.tr = str2double(tmp.tr);
+        p.te = str2double(tmp.te);
+        p.fa = str2double(tmp.fa);
+        switch inParName
+            case 'RepetitionTime' % [ms]
+                cRes = 1;
+                parLocation{cRes} = 'NiftiDescriptionField';
+                parValue{cRes} = p.tr;
+                fprintf(1,'Parameter available in NIFTI description field:\n\t%s = %5.2f ms\n', inParName, parValue{1});
+
+            case 'EchoTime'
+                cRes = 1;
+                parLocation{cRes} = 'NiftiDescriptionField';
+                parValue{cRes} = p.te;
+                fprintf(1,'Parameter available in NIFTI description field:\n\t%s = %5.2f ms\n', inParName, parValue{1});
+
+            case 'FlipAngle'
+                cRes = 1;
+                parLocation{cRes} = 'NiftiDescriptionField';
+                parValue{cRes} = p.fa;
+                fprintf(1,'Parameter available in NIFTI description field:\n\t%s = %5.2f deg\n', inParName, parValue{1});
+
+            otherwise
+                parLocation = [];
+                parValue = [];
+                fprintf(1,'Not able to retrieve any value for parameter %s.\n', inParName);
+        end
+    else
+        parLocation = [];
+        parValue = [];
+        fprintf(1,'Not able to retrieve any value for parameter %s.\n', inParName);
     end
-  else
-      error('Invalid input arguments. Type help get_metadata_val for correct syntax.');
-  end
+else
+    error('Invalid input arguments. Type help get_metadata_val for correct syntax.');
+end
 end


### PR DESCRIPTION
The B1 map creation code tries to check the TE values of the 3DEPI SE/STE data to see whether they can be used to sort the data in SE and STE following the [BIDS qMRI standard](https://bids-specification.readthedocs.io/en/stable/appendices/qmri.html#tb1epi-specific-notes). This caused a crash if the TE was not present in a json sidecar file, NIfTI extended header or the NIfTI description field. This is because the code to search the NIfTI description field did not define any output if TE could not be found. This has been fixed (for TE, TR and flip angle) by making this code return an empty array if the requested metadata cannot be found.

This code also fixes compatibility with SPM required due to [recent refactoring of SPM](https://github.com/spm/spm/commit/789dc3becd674dbe7c131764414bf651543727d5).