### PR TITLE
cherry-pick the spm25 commit: Fix when no TE provided in 3DEPI SE/STE B1 mapping data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Most recent version numbers *should* follow the [Semantic Versioning](https://se
 - use cell- instead of char- array to accommodate filenames of unequal length in RFsens
 - prevent missing B1 map for MTsat spamming the log
 - fix when no TE provided in 3DEPI SE/STE B1 mapping data
+- fixes compatibility with spm/spm required due to refactoring that removed TEMPLATE field
 
 ## [v0.6.1]
 ### Fixed

--- a/hmri_create_B1Map_unwarp.m
+++ b/hmri_create_B1Map_unwarp.m
@@ -46,8 +46,10 @@ IP.uflags.pad = pm_defs.PAD;
 IP.uflags.ws = pm_defs.WS;
 IP.uflags.etd = IP.et{2}-IP.et{1};
 
-% default brain extraction parameters (mflags) 
-IP.mflags.template = pm_defs.MFLAGS.TEMPLATE;
+% default brain extraction parameters (mflags)
+if isfield(pm_defs.MFLAGS,'TEMPLATE') % 'TEMPLATE' field no longer defined in pm_defs in the spm25 FieldMap toolbox
+    IP.mflags.template = pm_defs.MFLAGS.TEMPLATE;
+end
 IP.mflags.fwhm = pm_defs.MFLAGS.FWHM; 
 IP.mflags.nerode = pm_defs.MFLAGS.NERODE;
 IP.mflags.ndilate = pm_defs.MFLAGS.NDILATE;


### PR DESCRIPTION
This PR cherry-picks the spm25 commit in this PR:
https://github.com/hMRI-group/hMRI-toolbox/pull/120

in order to separately test and merge this specific commit, copying the original PR description from @lukeje :

This code also fixes compatibility with SPM required due to [recent refactoring of SPM](https://github.com/spm/spm/commit/789dc3becd674dbe7c131764414bf651543727d5).