### PR TITLE
denoising module: change nifti writing mode to prevent potential mat_intent modification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Most recent version numbers *should* follow the [Semantic Versioning](https://se
 - robust combination of two runs using error maps
 - add .orig file extension to .gitignore to prevent merge artifacts to be pushed
 - update GUI code to enhance documentation for Proc. Smoothing
+- denoising module (lcpca): set mat_intent fields to input file values instead of spm_create_vol setting of 'aligned'
 
 
 ### Fixed

--- a/hmri_denoising.m
+++ b/hmri_denoising.m
@@ -239,9 +239,10 @@ for echo = 1:length(image_list)
     filename = strcat('LcpcaDenoised_',filename,'.nii');
 
     outfname = fullfile(output_path{1}, filename);
-    filehdr.fname = outfname;
-    filehdr.descrip = strcat(filehdr.descrip, ' + lcpca denoised');
-    spm_write_vol(filehdr, volumedata);
+    dt = filehdr.dt;
+    updated_descrip = strcat(filehdr.descrip, ' + lcpca denoised');
+    denoised_nifti = hmri_create_nifti(outfname, filehdr, dt, updated_descrip);
+    denoised_nifti.dat(:,:,:) = volumedata;
 
     % write metadata as extended header and sidecar json
     Output_hdr = init_dn_output_metadata(fullim_list, lcpcadenoiseparams);
@@ -286,9 +287,10 @@ for echo = 1:length(image_list)
         filename = strcat('LcpcaDenoised_',filename,'.nii');
 
         outfname = fullfile(output_path{1}, filename);
-        filehdr.fname = outfname;
-        filehdr.descrip = strcat(filehdr.descrip, ' + lcpca denoised');
-        spm_write_vol(filehdr, volumedata);
+        dt = filehdr.dt;
+        updated_descrip = strcat(filehdr.descrip, ' + lcpca denoised');
+        denoised_nifti = hmri_create_nifti(outfname, filehdr, dt, updated_descrip);
+        denoised_nifti.dat(:,:,:)=volumedata;
 
         % write metadata as extended header and sidecar json
         Output_hdr = init_dn_output_metadata(fullim_list, lcpcadenoiseparams);


### PR DESCRIPTION
## Description

This PR updates the nifti writing mode within certain parts of the denoising module code to prevent possible mat_intent field modification:  observe that such modification does not effect our within toolbox processing (e.g. map creation) as explained here:

https://github.com/hMRI-group/hMRI-toolbox/issues/125

but might have adverse effects when other MRI software is used on the denoised images.

## Testing

Initial testing successful but full testing pending.

