### PR TITLE
Do not log ISC-applied to R1 in case of no-B1-corr and UNICORT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Most recent version numbers *should* follow the [Semantic Versioning](https://se
 - prevent missing B1 map for MTsat spamming the log
 - fix when no TE provided in 3DEPI SE/STE B1 mapping data
 - fixes compatibility with spm/spm required due to refactoring that removed TEMPLATE field
+- do not log ISC-applied to R1 in case of no-B1-corr and UNICORT
 
 ## [v0.6.1]
 ### Fixed

--- a/hmri_create_MTProt.m
+++ b/hmri_create_MTProt.m
@@ -1653,6 +1653,8 @@ if (mpm_params.T1widx && mpm_params.PDwidx)
     mpm_params.output(coutput).suffix = 'R1';
     mpm_params.output(coutput).units = 's-1';  
     mpm_params.output(coutput).descrip{1} = 'R1 map [s-1]';
+    % ISC not applied in case of no_B1_correction and UNICORT
+    % Therefore do not log ISC-applied to R1 in those cases
     if mpm_params.proc.ISC.enabled && ~strcmp(B1transcorr{1}, 'no_B1_correction') && ~strcmp(B1transcorr{1}, 'UNICORT')
         mpm_params.output(coutput).descrip{end+1} = '- Imperfect Spoiling Correction applied';
     else

--- a/hmri_create_MTProt.m
+++ b/hmri_create_MTProt.m
@@ -1653,7 +1653,7 @@ if (mpm_params.T1widx && mpm_params.PDwidx)
     mpm_params.output(coutput).suffix = 'R1';
     mpm_params.output(coutput).units = 's-1';  
     mpm_params.output(coutput).descrip{1} = 'R1 map [s-1]';
-    if mpm_params.proc.ISC.enabled && ~strcmp(B1transcorr{1}, 'no_B1_correction')
+    if mpm_params.proc.ISC.enabled && ~strcmp(B1transcorr{1}, 'no_B1_correction') && ~strcmp(B1transcorr{1}, 'UNICORT')
         mpm_params.output(coutput).descrip{end+1} = '- Imperfect Spoiling Correction applied';
     else
         mpm_params.output(coutput).descrip{end+1} = '- no Imperfect Spoiling Correction applied';

--- a/hmri_create_MTProt.m
+++ b/hmri_create_MTProt.m
@@ -1653,7 +1653,7 @@ if (mpm_params.T1widx && mpm_params.PDwidx)
     mpm_params.output(coutput).suffix = 'R1';
     mpm_params.output(coutput).units = 's-1';  
     mpm_params.output(coutput).descrip{1} = 'R1 map [s-1]';
-    if mpm_params.proc.ISC.enabled
+    if mpm_params.proc.ISC.enabled && ~strcmp(B1transcorr{1}, 'no_B1_correction')
         mpm_params.output(coutput).descrip{end+1} = '- Imperfect Spoiling Correction applied';
     else
         mpm_params.output(coutput).descrip{end+1} = '- no Imperfect Spoiling Correction applied';


### PR DESCRIPTION
The spoiling correction to R1 requires the existence of a B1 correction method (non-empty f_T), other than UNICORT.  When the current master is run with the spoiling correction on BUT with `no B1 correction` or `UNICORT` option, it falsely logs the R1 map as 

```
SUMMARY OF THE MAPS CALCULATED

(1) R1 map [s-1] (R1)
 - Imperfect Spoiling Correction applied
 - no B1+ bias correction applied
 - no RF sensitivity bias correction
```

this PR corrects this bug by requiring the presence of (non-UNICORT) B1 map to write the log ` - Imperfect Spoiling Correction applied` and in case of `no B1 map` or `UNICORT` (therefore no spoiling correction is applied to R1) it correctly logs:

```
(1) R1 map [s-1] (R1)
 - no Imperfect Spoiling Correction applied
 - no B1+ bias correction applied
 - no RF sensitivity bias correction
```

```
SUMMARY OF THE MAPS CALCULATED

(1) R1 map [s-1] (R1)
 - no Imperfect Spoiling Correction applied
 - B1+ bias correction using UNICORT
 - no RF sensitivity bias correction
```