### PR TITLE
Update defaults with new recommended options: no more small angle approximation, and using weighted least squares R2* fitting

### DIFF
--- a/config/hmri_defaults.m
+++ b/config/hmri_defaults.m
@@ -159,7 +159,7 @@ hmri_def.coreg_bias_flags.fwhm = [7 7];
 %--------------------------------------------------------------------------
 % Decide whether to use small angle approximation when computing R1 and PD
 %--------------------------------------------------------------------------
-hmri_def.small_angle_approx = true;
+hmri_def.small_angle_approx = false;
 
 %--------------------------------------------------------------------------
 % Which model to use for B1-correction of MTsat
@@ -190,7 +190,7 @@ hmri_def.R2sOLS = 1;
 %                            estimates; very slow, even with
 %                            parallelization over voxels. Recommend WLS1
 %                            instead)
-hmri_def.R2s_fit_method = 'OLS';
+hmri_def.R2s_fit_method = 'WLS1';
 
 % Minimum number of echoes to calculate R2s map. Strictly speaking, the
 % minimum is 2. For a robust estimation, the minimum number of echoes

--- a/config/local/hmri_local_defaults.m
+++ b/config/local/hmri_local_defaults.m
@@ -160,7 +160,7 @@ hmri_def.coreg_bias_flags.fwhm = [7 7];
 %--------------------------------------------------------------------------
 % Decide whether to use small angle approximation when computing R1 and PD
 %--------------------------------------------------------------------------
-hmri_def.small_angle_approx = true;
+hmri_def.small_angle_approx = false;
 
 %--------------------------------------------------------------------------
 % Which model to use for B1-correction of MTsat
@@ -191,7 +191,7 @@ hmri_def.R2sOLS = true;
 %                            estimates; very slow, even with
 %                            parallelization over voxels. Recommend WLS1
 %                            instead)
-hmri_def.R2s_fit_method = 'OLS';
+hmri_def.R2s_fit_method = 'WLS1';
 
 % Minimum number of echoes to calculate R2s map. Strictly speaking, the
 % minimum is 2. For a robust estimation, the minimum number of echoes


### PR DESCRIPTION
The planned release of version 1.0 of the toolbox allows us the opportunity to update the defaults with the latest recommended options so that people get more optimal maps with just the default settings. Note that these changes will break backwards compatibility: it is important to run all datasets in a study using the same version of the hMRI toolbox.