### PR TITLE
Fix default AFI TR2/TR1 value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,12 +40,14 @@ Most recent version numbers *should* follow the [Semantic Versioning](https://se
 - do not log ISC-applied to R1 in case of no-B1-corr and UNICORT
 - account for diffusion while gradients are off when calculating imperfect spoiling correction parameters
 - apply shift and diffusion operators in the correct order when calculating imperfect spoiling correction parameters
+- Default AFI TR2/TR1 value now matches typical sequence order
 
 ### Breaking changes
 - Old, unused imperfect spoiling correction coefficients have been removed and replaced with new ones.
   If you need the old coefficients, you will need to add them back using a local defaults file.
 - Fix inconsistency between new implementation of PD and old T2* weighting removal method
 - Update imperfect spoiling correction with upstream bugfixes in EPG-X so computed coefficients will be different
+- Default AFI TR2/TR1 value now based on the second input image having the longer TR, which may not be the case for older data
 
 ## [v0.6.1]
 ### Fixed

--- a/config/hmri_b1_standard_defaults.m
+++ b/config/hmri_b1_standard_defaults.m
@@ -44,7 +44,7 @@ global hmri_def
 hmri_def.b1map.i3D_AFI.b1type = 'i3D_AFI'; 
 hmri_def.b1map.i3D_AFI.b1avail = true; 
 hmri_def.b1map.i3D_AFI.procreq = true; 
-hmri_def.b1map.i3D_AFI.b1acq.TR2TR1ratio = 0.2; % TR of second input volume over TR of first input volume
+hmri_def.b1map.i3D_AFI.b1acq.TR2TR1ratio = 5; % TR of second input volume over TR of first input volume
 hmri_def.b1map.i3D_AFI.b1acq.alphanom = 60;
 hmri_def.b1map.i3D_AFI.b1mask.domask = false; % whether to mask using hmri_create_pm_brain_mask.m
 hmri_def.b1map.i3D_AFI.b1mask.fwhm = 5; % options for hmri_create_pm_brain_mask.m

--- a/config/local/hmri_b1_local_defaults.m
+++ b/config/local/hmri_b1_local_defaults.m
@@ -52,7 +52,7 @@ global hmri_def
 hmri_def.b1map.i3D_AFI.b1type = 'i3D_AFI'; 
 hmri_def.b1map.i3D_AFI.b1avail = true; 
 hmri_def.b1map.i3D_AFI.procreq = true; 
-hmri_def.b1map.i3D_AFI.b1acq.TR2TR1ratio = 0.2; % TR of second input volume over TR of first input volume
+hmri_def.b1map.i3D_AFI.b1acq.TR2TR1ratio = 5; % TR of second input volume over TR of first input volume
 hmri_def.b1map.i3D_AFI.b1acq.alphanom = 60;
 hmri_def.b1map.i3D_AFI.b1mask.domask = false; % whether to mask using hmri_create_pm_brain_mask.m
 hmri_def.b1map.i3D_AFI.b1mask.fwhm = 5; % options for hmri_create_pm_brain_mask.m


### PR DESCRIPTION
All recent AFI protocols in Leipzig have had short TR1 and long TR2, however the default files have this the other way around. This fix will make it easier for people to just use the defaults, rather than having to provide their own defaults file.